### PR TITLE
[FEAT]  Add runtime in-memory-db update support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.76"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59d2a3357dde987206219e78ecfbbb6e8dad06cbb65292758d3270e6254f7355"
+checksum = "c9d19de80eff169429ac1e9f48fffb163916b448a44e8e046186232046d9e1f9"
 
 [[package]]
 name = "arc-swap"
@@ -1806,18 +1806,18 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
+checksum = "83a48fd946b02c0a526b2e9481c8e2a17755e47039164a86c4070446e3a4614d"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.51"
+version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
+checksum = "e7fbe9b594d6568a6a1443250a7e67d80b74e1e96f6d1715e1e21cc1888291d3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Additionally, client (X.509) certificates are created w/a subject alternative na
 URI = {"userId": <USER_ID>, "platform": <DEVICE_PLATFORM>"}
 ```
 
-This allows the gateway to identify the user by their "userId" value (currently platform is not used). Subsequently, the gateway can enforce the appropriate authorization for their session.
+This allows the gateway to identify the user by their "userId" value (currently platform is not used). Subsequently, the gateway can enforce the appropriate authorization for their session. For instance it will check the respective [User Table](#user-table) record for the current status (values: `Active`, `Inactive`). Additionally if they are making a service proxy connection, it will validate the service and if the user has appropriate access by looking up the appropriate records in the [Service Table](#service-table) and [Access Table](#access-table).
 
 All connections use the same gateway port. The gateway knows the kind of connection based on the TLS application-layer protocol negotiation (ALPN) value given by the Trust0 client. The types of values are as follows:
 
@@ -194,7 +194,11 @@ For more details on using the CRL feature:
 
 ### Database
 
-The database is used to enforce user access to Trust0 and the respective services. Currently only a simple in-memory DB based on JSON files is available. The repository is exposed as an abstract trait, so additional DB implementations may be developed.
+The database is used to enforce user access to Trust0 and the respective services.
+
+Currently only a simple in-memory DB based on JSON files is available. At runtime, the system will periodically scan for file changes and reload the corresponding DB with latest records from the changed file.
+
+The repository is exposed as an abstract trait, so additional DB implementations may be developed.
 
 #### User Table
 

--- a/crates/common/src/file.rs
+++ b/crates/common/src/file.rs
@@ -1,6 +1,17 @@
+use std::ops::DerefMut;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::{fs, thread};
+
+use anyhow::Result;
+
 use crate::error::AppError;
-use std::path::Path;
-use std::time::SystemTime;
+use crate::logging::{error, info};
+use crate::target;
+
+const RELOADABLEFILE_RECHECK_DELAY_MSECS: Duration = Duration::from_millis(30_000);
 
 /// Return file modification time
 pub fn file_mtime(filepath: &Path) -> Result<SystemTime, AppError> {
@@ -14,9 +25,183 @@ pub fn file_mtime(filepath: &Path) -> Result<SystemTime, AppError> {
         },
 
         Err(err) => Err(AppError::GenWithMsgAndErr(
-            format!("Error acquiring CRL file metadata: file={:?}", filepath),
+            format!("Error acquiring file metadata: file={:?}", filepath),
             Box::new(err),
         )),
+    }
+}
+
+/// Load data as text string from given file
+pub fn load_text_data(filepath_str: &str) -> Result<String, AppError> {
+    fs::read_to_string(filepath_str).map_err(|err| {
+        AppError::GenWithMsgAndErr(
+            format!("Failed to read file: path={}", filepath_str),
+            Box::new(err),
+        )
+    })
+}
+
+/// Represents a file resource that is reloadable upon file change events.
+pub trait ReloadableFile: Send {
+    /// file path accessor
+    fn filepath(&self) -> &PathBuf;
+
+    /// Stores the last file modified time seen
+    fn last_file_mtime(&mut self) -> &mut SystemTime;
+
+    /// reload data callback function
+    fn on_reload_data(&mut self) -> Result<(), AppError>;
+
+    /// critical-level error callback function
+    fn on_critical_error(&mut self, err: &AppError);
+
+    /// reloading loop processing state
+    fn reloading(&self) -> &Arc<Mutex<bool>>;
+
+    /// Trigger file reload, if file has changed. Returns true if file was reloaded
+    fn process_reload(&mut self) -> Result<bool, AppError> {
+        // Check if file has changed
+        let filepath = self.filepath().clone();
+        let last_file_mtime = self.last_file_mtime();
+        match file_mtime(filepath.as_path()) {
+            Ok(file_mtime) => {
+                if *last_file_mtime == file_mtime {
+                    return Ok(false);
+                }
+                last_file_mtime.clone_from(&file_mtime);
+            }
+            Err(err) => {
+                self.on_critical_error(&err);
+                return Err(err);
+            }
+        }
+
+        // Process new file contents
+        self.on_reload_data()?;
+
+        Ok(true)
+    }
+
+    /// Spawn a thread to handle re-loading if file changes.
+    /// If recheck delay is not supplied, a default of 30s will be used.
+    fn spawn_reloader(
+        mut reloadable_file: impl ReloadableFile + 'static,
+        recheck_delay: Option<Duration>,
+    ) where
+        Self: Sized,
+    {
+        info(
+            &target!(),
+            &format!(
+                "Starting file reloader: file={:?}",
+                &reloadable_file.filepath()
+            ),
+        );
+
+        thread::spawn(move || {
+            let file_pathbuf = reloadable_file.filepath().to_str().unwrap().to_string();
+            let recheck_delay = recheck_delay.unwrap_or(RELOADABLEFILE_RECHECK_DELAY_MSECS);
+
+            let is_reloading = reloadable_file.reloading().clone();
+
+            *is_reloading.lock().unwrap() = true;
+            while *is_reloading.lock().unwrap() {
+                match reloadable_file.process_reload() {
+                    Ok(reloaded) => {
+                        if reloaded {
+                            info(
+                                &target!(),
+                                &format!(
+                                    "Processed changed file: file={:?}, mtime={:?}",
+                                    &file_pathbuf,
+                                    reloadable_file.last_file_mtime()
+                                ),
+                            );
+                        }
+                    }
+                    Err(err) => error(&target!(), &format!("{:?}", err)),
+                }
+
+                thread::sleep(recheck_delay);
+            }
+
+            info(
+                &target!(),
+                &format!("Stopped file reloader: file={:?}", &file_pathbuf),
+            );
+        });
+    }
+}
+
+/// Represents a reloadable text file
+pub struct ReloadableTextFile {
+    path: PathBuf,
+    last_mtime: SystemTime,
+    text_data: Arc<Mutex<String>>,
+    reloading: Arc<Mutex<bool>>,
+}
+
+impl ReloadableTextFile {
+    /// ReloadableTextFile constructor
+    pub fn new(
+        filepath_str: &str,
+        text_data: &Arc<Mutex<String>>,
+        reloading: &Arc<Mutex<bool>>,
+    ) -> Result<Self, AppError> {
+        let filepath = PathBuf::from_str(filepath_str).map_err(|err| {
+            AppError::GenWithMsgAndErr(
+                format!(
+                    "Error converting string to file path: file={}",
+                    filepath_str
+                ),
+                Box::new(err),
+            )
+        })?;
+        Ok(ReloadableTextFile {
+            path: filepath,
+            last_mtime: UNIX_EPOCH,
+            text_data: text_data.clone(),
+            reloading: reloading.clone(),
+        })
+    }
+
+    /// Text data accessor
+    pub fn text_data(&mut self) -> Arc<Mutex<String>> {
+        self.text_data.clone()
+    }
+}
+
+impl ReloadableFile for ReloadableTextFile {
+    fn filepath(&self) -> &PathBuf {
+        &self.path
+    }
+
+    fn last_file_mtime(&mut self) -> &mut SystemTime {
+        &mut self.last_mtime
+    }
+
+    fn on_reload_data(&mut self) -> Result<(), AppError> {
+        match load_text_data(self.path.to_str().unwrap()) {
+            Ok(text_data) => {
+                *self.text_data.lock().unwrap().deref_mut() = text_data;
+                Ok(())
+            }
+            Err(err) => Err(AppError::GenWithMsgAndErr(
+                format!("Error loading file: file={:?}", &self.path),
+                Box::new(err),
+            )),
+        }
+    }
+
+    fn on_critical_error(&mut self, err: &AppError) {
+        panic!(
+            "Error during text file reload, exiting: file={:?}, err={:?}",
+            &self.path, &err
+        );
+    }
+
+    fn reloading(&self) -> &Arc<Mutex<bool>> {
+        &self.reloading
     }
 }
 
@@ -59,5 +244,321 @@ mod tests {
                 &file_pathbuf, &result
             );
         }
+    }
+}
+
+/// ReloadableFile unit tests
+#[cfg(test)]
+mod reload_tests {
+    use super::*;
+    use crate::file::ReloadableFile;
+    use std::ops::Deref;
+    use std::path::PathBuf;
+
+    // constants
+    // =========
+
+    const FILE_REVOKED_CERTS_0_PATHPARTS: [&str; 3] = [
+        env!("CARGO_MANIFEST_DIR"),
+        "testdata",
+        "revoked-crts-0.crl.pem",
+    ];
+    const _FILE_REVOKED_CERTS_0_1_PATHPARTS: [&str; 3] = [
+        env!("CARGO_MANIFEST_DIR"),
+        "testdata",
+        "revoked-crts-0-1.crl.pem",
+    ];
+    const FILE_MISSING_PATHPARTS: [&str; 3] =
+        [env!("CARGO_MANIFEST_DIR"), "testdata", "NON-EXISTENT.txt"];
+
+    const FILE_INVALID_CRL_PATHPARTS: [&str; 3] =
+        [env!("CARGO_MANIFEST_DIR"), "testdata", "invalid.crl.pem"];
+
+    // classes
+    // =======
+
+    #[derive(Debug, PartialEq)]
+    enum ReloadFileAction {
+        None,
+        CritErr(String),
+        Reload,
+    }
+
+    #[derive(Debug)]
+    struct ReloadFileImpl {
+        path: PathBuf,
+        last_mtime: SystemTime,
+        action: ReloadFileAction,
+        reloading: Arc<Mutex<bool>>,
+    }
+
+    impl ReloadableFile for ReloadFileImpl {
+        fn filepath(&self) -> &PathBuf {
+            &self.path
+        }
+        fn last_file_mtime(&mut self) -> &mut SystemTime {
+            &mut self.last_mtime
+        }
+        fn on_reload_data(&mut self) -> Result<(), AppError> {
+            self.action = ReloadFileAction::Reload;
+            Ok(())
+        }
+        fn on_critical_error(&mut self, err: &AppError) {
+            self.action = ReloadFileAction::CritErr(format!("{:?}", err));
+        }
+        fn reloading(&self) -> &Arc<Mutex<bool>> {
+            &self.reloading
+        }
+    }
+
+    #[test]
+    fn reloadfile_accessors() {
+        let filepath: PathBuf = FILE_REVOKED_CERTS_0_PATHPARTS.iter().collect();
+        let last_mtime = file_mtime(filepath.as_path()).unwrap();
+
+        let mut file = ReloadFileImpl {
+            path: filepath.clone(),
+            last_mtime: last_mtime.clone(),
+            action: ReloadFileAction::None,
+            reloading: Arc::new(Mutex::new(true)),
+        };
+
+        assert_eq!(*file.filepath(), filepath);
+        assert_eq!(*file.last_file_mtime(), last_mtime);
+        assert!(*file.reloading().lock().unwrap());
+
+        file.on_reload_data().unwrap();
+        assert_eq!(file.action, ReloadFileAction::Reload);
+
+        let error = AppError::WouldBlock;
+        file.on_critical_error(&error);
+        assert_eq!(
+            file.action,
+            ReloadFileAction::CritErr("WouldBlock".to_string())
+        );
+    }
+
+    #[test]
+    fn reloadfile_process_reload_when_file_unchanged() {
+        let filepath: PathBuf = FILE_REVOKED_CERTS_0_PATHPARTS.iter().collect();
+        let filepath_str = filepath.to_str().unwrap().to_string();
+        let last_mtime = file_mtime(filepath.as_path()).unwrap();
+        let saved_last_mtime = last_mtime.clone();
+
+        let mut file = ReloadFileImpl {
+            path: filepath,
+            last_mtime,
+            action: ReloadFileAction::None,
+            reloading: Arc::new(Mutex::new(true)),
+        };
+
+        let result = file.process_reload();
+        if let Err(err) = result {
+            panic!(
+                "Unexpected processed reload result: path={}, err={:?}",
+                &filepath_str, &err
+            );
+        }
+        let was_reloaded = result.unwrap();
+
+        assert_eq!(was_reloaded, false);
+        assert_eq!(file.action, ReloadFileAction::None);
+        assert_eq!(file.last_mtime, saved_last_mtime);
+    }
+
+    #[test]
+    fn reloadfile_process_reload_when_file_changed() {
+        let filepath: PathBuf = FILE_REVOKED_CERTS_0_PATHPARTS.iter().collect();
+        let filepath_str = filepath.to_str().unwrap().to_string();
+        let last_mtime = SystemTime::now();
+        let saved_last_mtime = last_mtime.clone();
+
+        let mut file = ReloadFileImpl {
+            path: filepath,
+            last_mtime,
+            action: ReloadFileAction::None,
+            reloading: Arc::new(Mutex::new(true)),
+        };
+
+        let result = file.process_reload();
+        if let Err(err) = result {
+            panic!(
+                "Unexpected processed reload result: path={}, err={:?}",
+                &filepath_str, &err
+            );
+        }
+        let was_reloaded = result.unwrap();
+
+        assert_eq!(was_reloaded, true);
+        assert_eq!(file.action, ReloadFileAction::Reload);
+        assert_ne!(file.last_mtime, saved_last_mtime);
+    }
+
+    #[test]
+    fn reloadfile_process_reload_when_invalid_filepath() {
+        let filepath: PathBuf = FILE_MISSING_PATHPARTS.iter().collect();
+        let filepath_str = filepath.to_str().unwrap().to_string();
+        let last_mtime = SystemTime::now();
+        let saved_last_mtime = last_mtime.clone();
+
+        let mut file = ReloadFileImpl {
+            path: filepath,
+            last_mtime,
+            action: ReloadFileAction::None,
+            reloading: Arc::new(Mutex::new(true)),
+        };
+
+        let _ = file.process_reload();
+        let result = file.process_reload();
+        if let Ok(reloaded) = result {
+            panic!(
+                "Unexpected processed reload result: path={}, reload={}",
+                &filepath_str, &reloaded
+            );
+        }
+
+        assert_eq!(file.last_mtime, saved_last_mtime);
+
+        match &file.action {
+            ReloadFileAction::CritErr(_) => {}
+            _ => panic!("Unexpected action: val={:?}", &file.action),
+        }
+    }
+
+    #[test]
+    fn reloadfile_spawn_reloader() {
+        let filepath: PathBuf = FILE_REVOKED_CERTS_0_PATHPARTS.iter().collect();
+        let last_mtime = SystemTime::now();
+        let reloading = Arc::new(Mutex::new(false));
+
+        let file = ReloadFileImpl {
+            path: filepath,
+            last_mtime,
+            action: ReloadFileAction::None,
+            reloading: reloading.clone(),
+        };
+
+        <ReloadFileImpl as ReloadableFile>::spawn_reloader(file, Some(Duration::from_millis(10)));
+        *reloading.lock().unwrap() = false;
+    }
+
+    #[test]
+    fn reloadtext_new() {
+        let filepath: PathBuf = FILE_INVALID_CRL_PATHPARTS.iter().collect();
+        let text_data = Arc::new(Mutex::new("txt1".to_string()));
+
+        let text_file_result = ReloadableTextFile::new(
+            filepath.to_str().unwrap(),
+            &text_data,
+            &Arc::new(Mutex::new(true)),
+        );
+
+        if let Err(err) = text_file_result {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+
+        let mut text_file = text_file_result.unwrap();
+
+        assert_eq!(*text_file.filepath(), filepath);
+        assert_eq!(
+            *text_file.text_data().lock().unwrap().deref(),
+            "txt1".to_string()
+        );
+        assert!(*text_file.reloading().lock().unwrap());
+    }
+
+    #[test]
+    fn reloadtext_accessors() {
+        let filepath: PathBuf = FILE_INVALID_CRL_PATHPARTS.iter().collect();
+        let text_data = Arc::new(Mutex::new(String::new()));
+        let last_mtime = file_mtime(filepath.as_path()).unwrap();
+
+        let mut text_file = ReloadableTextFile {
+            path: filepath.clone(),
+            last_mtime,
+            text_data: text_data.clone(),
+            reloading: Arc::new(Mutex::new(true)),
+        };
+
+        assert_eq!(*text_file.filepath(), filepath);
+        assert_eq!(*text_file.last_file_mtime(), last_mtime);
+        assert!(*text_file.reloading().lock().unwrap());
+    }
+
+    #[test]
+    fn reloadtext_process_reload_when_file_unchanged() {
+        let filepath: PathBuf = FILE_INVALID_CRL_PATHPARTS.iter().collect();
+        let filepath_str = filepath.to_str().unwrap().to_string();
+        let text_data = Arc::new(Mutex::new(String::new()));
+        let last_mtime = file_mtime(filepath.as_path()).unwrap();
+        let saved_last_mtime = last_mtime.clone();
+
+        let mut text_file = ReloadableTextFile {
+            path: filepath.clone(),
+            last_mtime,
+            text_data: text_data.clone(),
+            reloading: Arc::new(Mutex::new(true)),
+        };
+
+        let result = text_file.process_reload();
+        if let Err(err) = result {
+            panic!(
+                "Unexpected processed text data reload result: path={}, err={:?}",
+                &filepath_str, &err
+            );
+        }
+        let was_reloaded = result.unwrap();
+
+        assert_eq!(was_reloaded, false);
+        assert_eq!(text_file.last_mtime, saved_last_mtime);
+        assert!(text_data.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn reloadtext_process_reload_when_file_changed() {
+        let filepath: PathBuf = FILE_INVALID_CRL_PATHPARTS.iter().collect();
+        let filepath_str = filepath.to_str().unwrap().to_string();
+        let text_data = Arc::new(Mutex::new(String::new()));
+        let last_mtime = SystemTime::now();
+        let saved_last_mtime = last_mtime.clone();
+
+        let mut text_file = ReloadableTextFile {
+            path: filepath.clone(),
+            last_mtime,
+            text_data: text_data.clone(),
+            reloading: Arc::new(Mutex::new(true)),
+        };
+
+        let result = text_file.process_reload();
+        if let Err(err) = result {
+            panic!(
+                "Unexpected processed text data reload result: path={}, err={:?}",
+                &filepath_str, &err
+            );
+        }
+        let was_reloaded = result.unwrap();
+
+        assert_eq!(was_reloaded, true);
+        assert_ne!(text_file.last_mtime, saved_last_mtime);
+        assert!(!text_data.lock().unwrap().is_empty());
+        assert_eq!(text_data.lock().unwrap().to_string().replace(" ", ""),
+                   "-----BEGINX509CRL-----\nWRONG1\n-----ENDX509CRL-----\n-----BEGINX509CRL-----\nWRONG2\n-----ENDX509CRL-----\n".to_string());
+    }
+
+    #[test]
+    #[should_panic]
+    fn reloadtext_process_reload_when_invalid_filepath() {
+        let filepath: PathBuf = FILE_MISSING_PATHPARTS.iter().collect();
+        let text_data = Arc::new(Mutex::new(String::new()));
+        let last_mtime = file_mtime(filepath.as_path()).unwrap();
+
+        let mut text_file = ReloadableTextFile {
+            path: filepath.clone(),
+            last_mtime,
+            text_data: text_data.clone(),
+            reloading: Arc::new(Mutex::new(true)),
+        };
+
+        let _ = text_file.process_reload();
     }
 }

--- a/crates/gateway/src/repository/access_repo/in_memory_repo.rs
+++ b/crates/gateway/src/repository/access_repo/in_memory_repo.rs
@@ -1,20 +1,31 @@
 use std::collections::HashMap;
 use std::fs;
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::{Arc, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use crate::repository::access_repo::AccessRepository;
 use trust0_common::error::AppError;
+use trust0_common::file::{ReloadableFile, ReloadableTextFile};
+use trust0_common::logging::error;
 use trust0_common::model::access::ServiceAccess;
+use trust0_common::target;
 
 pub struct InMemAccessRepo {
     accesses: RwLock<HashMap<(u64, u64), ServiceAccess>>,
+    source_file: Option<String>,
+    reloader_loading: Arc<Mutex<bool>>,
+    reloader_new_data: Arc<Mutex<String>>,
 }
 
 impl InMemAccessRepo {
     /// Creates a new in-memory service access store.
     pub fn new() -> InMemAccessRepo {
+        let reloader_loading = Arc::new(Mutex::new(false));
+        let reloader_new_data = Arc::new(Mutex::new(String::new()));
         InMemAccessRepo {
             accesses: RwLock::new(HashMap::new()),
+            source_file: None,
+            reloader_loading,
+            reloader_new_data,
         }
     }
 
@@ -22,6 +33,12 @@ impl InMemAccessRepo {
     fn access_data_for_write(
         &self,
     ) -> Result<RwLockWriteGuard<HashMap<(u64, u64), ServiceAccess>>, AppError> {
+        if let Err(err) = self.process_source_data_updates() {
+            error(
+                &target!(),
+                &format!("Error processing updates: err={:?}", &err),
+            );
+        }
         self.accesses.write().map_err(|err| {
             AppError::General(format!("Failed to access write lock to DB: err={}", err))
         })
@@ -31,14 +48,63 @@ impl InMemAccessRepo {
     fn access_data_for_read(
         &self,
     ) -> Result<RwLockReadGuard<HashMap<(u64, u64), ServiceAccess>>, AppError> {
+        if let Err(err) = self.process_source_data_updates() {
+            error(
+                &target!(),
+                &format!("Error processing updates: err={:?}", &err),
+            );
+        }
         self.accesses.read().map_err(|err| {
             AppError::General(format!("Failed to access read lock to DB: err={}", err))
         })
+    }
+
+    /// If new (unparsed JSON) data has been queued by the reloader, replace DB accordingly
+    fn process_source_data_updates(&self) -> Result<(), AppError> {
+        // Check if new data is pending
+        if self.reloader_new_data.lock().unwrap().is_empty() {
+            return Ok(());
+        }
+
+        // Parse new (JSON) data
+        let accesses: Vec<ServiceAccess> = serde_json::from_str(
+            self.reloader_new_data.lock().unwrap().as_str(),
+        )
+        .map_err(|err| {
+            AppError::GenWithMsgAndErr(
+                format!(
+                    "Failed to parse JSON: path={}",
+                    &self.source_file.as_ref().unwrap()
+                ),
+                Box::new(err),
+            )
+        })?;
+
+        // Update database
+        let mut data = self.accesses.write().map_err(|err| {
+            AppError::General(format!(
+                "Failed to access write lock to DB: path={}, err={}",
+                self.source_file.as_ref().unwrap(),
+                err
+            ))
+        })?;
+
+        data.clear();
+        for access in accesses.iter().as_ref() {
+            data.insert((access.user_id, access.service_id), access.clone());
+        }
+
+        self.reloader_new_data.lock().unwrap().clear();
+
+        Ok(())
     }
 }
 
 impl AccessRepository for InMemAccessRepo {
     fn connect_to_datasource(&mut self, connect_spec: &str) -> Result<(), AppError> {
+        // Load DB from JSON file
+        self.source_file = Some(connect_spec.to_string());
+
         let data = fs::read_to_string(connect_spec).map_err(|err| {
             AppError::GenWithMsgAndErr(
                 format!("Failed to read file: path={}", connect_spec),
@@ -55,6 +121,15 @@ impl AccessRepository for InMemAccessRepo {
         for access in accesses.iter().as_ref() {
             self.put(access.clone())?;
         }
+
+        // Spawn DB reload thread
+        let reloadable_file = ReloadableTextFile::new(
+            connect_spec,
+            &self.reloader_new_data,
+            &self.reloader_loading,
+        )?;
+
+        <ReloadableTextFile as ReloadableFile>::spawn_reloader(reloadable_file, None);
 
         Ok(())
     }
@@ -181,6 +256,92 @@ mod tests {
                 .count(),
             0
         );
+
+        *access_repo.reloader_loading.lock().unwrap() = false;
+    }
+
+    #[test]
+    fn inmemaccessrepo_process_source_data_updates_when_valid_json() {
+        let valid_access_db_path: PathBuf = VALID_ACCESS_DB_FILE_PATHPARTS.iter().collect();
+        let valid_access_db_pathstr = valid_access_db_path.to_str().unwrap();
+
+        let mut access_repo = InMemAccessRepo::new();
+
+        if let Err(err) = access_repo.connect_to_datasource(valid_access_db_pathstr) {
+            panic!(
+                "Unexpected result: file={}, err={:?}",
+                valid_access_db_pathstr, &err
+            );
+        }
+
+        assert_eq!(access_repo.accesses.read().unwrap().len(), 5);
+
+        *access_repo.reloader_new_data.lock().unwrap() =
+            "[{\"userId\": 800, \"serviceId\": 900}]".to_string();
+
+        if let Err(err) = access_repo.process_source_data_updates() {
+            panic!("Unexpected process updates result: err={:?}", &err);
+        }
+
+        let expected_access_db_map: HashMap<(u64, u64), ServiceAccess> = HashMap::from([(
+            (800, 900),
+            ServiceAccess {
+                user_id: 100,
+                service_id: 200,
+            },
+        )]);
+
+        let actual_access_db_map: HashMap<(u64, u64), ServiceAccess> = HashMap::from_iter(
+            access_repo
+                .accesses
+                .into_inner()
+                .unwrap()
+                .iter()
+                .map(|e| (e.0.clone(), e.1.clone()))
+                .collect::<Vec<((u64, u64), ServiceAccess)>>(),
+        );
+
+        assert_eq!(actual_access_db_map.len(), expected_access_db_map.len());
+        assert_eq!(
+            actual_access_db_map
+                .iter()
+                .filter(|entry| !expected_access_db_map.contains_key(entry.0))
+                .count(),
+            0
+        );
+
+        *access_repo.reloader_loading.lock().unwrap() = false;
+    }
+
+    #[test]
+    fn inmemaccessrepo_process_source_data_updates_when_invalid_json() {
+        let valid_access_db_path: PathBuf = VALID_ACCESS_DB_FILE_PATHPARTS.iter().collect();
+        let valid_access_db_pathstr = valid_access_db_path.to_str().unwrap();
+
+        let mut access_repo = InMemAccessRepo::new();
+
+        if let Err(err) = access_repo.connect_to_datasource(valid_access_db_pathstr) {
+            panic!(
+                "Unexpected result: file={}, err={:?}",
+                valid_access_db_pathstr, &err
+            );
+        }
+
+        assert_eq!(access_repo.accesses.read().unwrap().len(), 5);
+
+        *access_repo.reloader_new_data.lock().unwrap() =
+            "[{\"userId\": 800, \"serviceId\": 900}".to_string();
+
+        if let Ok(()) = access_repo.process_source_data_updates() {
+            panic!(
+                "Unexpected successfule process updates result: file={}",
+                valid_access_db_pathstr
+            );
+        }
+
+        assert_eq!(access_repo.accesses.read().unwrap().len(), 5);
+
+        *access_repo.reloader_loading.lock().unwrap() = false;
     }
 
     #[test]


### PR DESCRIPTION
### Summary

Now the 3 in-memory-db's (`access`, `service` and `user`) will be updated without gateway downtime with any changes corresponding to their source files (when those files mtimes change).

A new common trait for performing the core reloading strategy was added, in addition to a common trait for reloading simple text files (as is needed for these DBs).

The CRLFile reloader was refactored to use this new trait as well.