### PR TITLE
[TASK] Bump version to 0.4.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1915,7 +1915,7 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 
 [[package]]
 name = "trust0-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -1942,7 +1942,7 @@ dependencies = [
 
 [[package]]
 name = "trust0-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "clap",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "trust0-gateway"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
  "clap",

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ This is very early alpha, use with care.
 * Build (more) testing: unit, integration, performance, ...
 * Strategize non-name resolution (DNS/hosts file/...) approach to handle client TLS hostname verification for service connections
 * Supply more comprehensive source commenting
-* Develop tool: Trust0 client installer (dotfiles/... location for binary and supporting files)
 * Consider supporting UDP multicast services
 * Consider gateway-to-gateway service proxy routing (reasons of proximity, security, ...)
 * Consider gateway load-balancing, via client redirect (reasons of load, rollout deployment, ...)

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trust0-client"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 description = "Trust0 SDP Service Proxy Client"
 repository = "https://github.com/chewyfish/trust0"
 edition = "2021"
@@ -26,7 +26,7 @@ sct = "0.7.1"
 serde = { version = "*", features = ["derive"] }
 serde_derive = "*"
 serde_json = { version = "*", features = ["arbitrary_precision"] }
-trust0-common = { version = "0.3.0-alpha", path = "../common" }
+trust0-common = { version = "0.4.0-alpha", path = "../common" }
 webpki-roots = "0.25"
 
 [dev-dependencies]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trust0-common"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 description = "Trust0 SDP Shared Codebase"
 repository = "https://github.com/chewyfish/trust0"
 edition = "2021"

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trust0-gateway"
-version = "0.3.0-alpha"
+version = "0.4.0-alpha"
 description = "Trust0 SDP Service Proxy Gateway"
 repository = "https://github.com/chewyfish/trust0"
 edition = "2021"
@@ -29,7 +29,7 @@ serde = { version = "*", features = ["derive"] }
 serde_derive = "*"
 serde_json = { version = "*", features = ["arbitrary_precision"] }
 shlex = "1.2.0"
-trust0-common = { version = "0.3.0-alpha", path = "../common" }
+trust0-common = { version = "0.4.0-alpha", path = "../common" }
 webpki-roots = "0.26.0"
 x509-parser = "0.15.1"
 regex = "1.10.2"


### PR DESCRIPTION
### Summary

* Update crates' version to `0.4.0-alpha`
* Remove `add client installer` from README to-do list