### PR TITLE
[FEAT] Added MFA/secondary authentication support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1567,6 +1567,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rpassword"
+version = "7.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80472be3c897911d0137b2d2b9055faf6eeac5b14e324073d83bc17b191d7e3f"
+dependencies = [
+ "libc",
+ "rtoolbox",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c247d24e63230cdb56463ae328478bd5eac8b8faa8c69461a77e8e323afac90e"
+dependencies = [
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1946,6 +1967,7 @@ dependencies = [
  "once_cell",
  "rcgen",
  "ring 0.17.7",
+ "rpassword",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+checksum = "4cd2405b3ac1faab2990b74d728624cd9fd115651fcecc7c2d8daf01376275ba"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -155,7 +155,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
 dependencies = [
- "async-lock 3.2.0",
+ "async-lock 3.3.0",
  "async-task",
  "concurrent-queue",
  "fastrand 2.0.1",
@@ -172,7 +172,7 @@ dependencies = [
  "async-channel 2.1.1",
  "async-executor",
  "async-io 2.2.2",
- "async-lock 3.2.0",
+ "async-lock 3.3.0",
  "blocking",
  "futures-lite 2.2.0",
  "once_cell",
@@ -204,14 +204,14 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6afaa937395a620e33dc6a742c593c01aced20aa376ffb0f628121198578ccc7"
 dependencies = [
- "async-lock 3.2.0",
+ "async-lock 3.3.0",
  "cfg-if 1.0.0",
  "concurrent-queue",
  "futures-io",
  "futures-lite 2.2.0",
  "parking",
  "polling 3.3.1",
- "rustix 0.38.28",
+ "rustix 0.38.30",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7125e42787d53db9dd54261812ef17e937c95a51e4d291373b670342fa44310c"
+checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
 dependencies = [
  "event-listener 4.0.3",
  "event-listener-strategy",
@@ -250,7 +250,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.28",
+ "rustix 0.38.30",
  "windows-sys 0.48.0",
 ]
 
@@ -266,7 +266,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "futures-core",
  "futures-io",
- "rustix 0.38.28",
+ "rustix 0.38.30",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.48.0",
@@ -350,9 +350,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.6"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79fed4cdb43e993fcdadc7e58a09fd0e3e649c4436fa11da71c9f1f3ee7feb9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bitflags"
@@ -373,7 +373,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
 dependencies = [
  "async-channel 2.1.1",
- "async-lock 3.2.0",
+ "async-lock 3.3.0",
  "async-task",
  "fastrand 2.0.1",
  "futures-io",
@@ -443,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.13"
+version = "4.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bdc885e4cacc7f7c9eedc1ef6da641603180c783c41a15c264944deeaab642"
+checksum = "58e54881c004cec7895b0068a0a954cd5d62da01aef83fa35b1e594497bf5445"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.12"
+version = "4.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb7fb5e4e979aec3be7791562fcba452f94ad85e954da024396433e0e25a79e9"
+checksum = "59cb82d7f531603d2fd1f507441cdd35184fa81beff7bd489570de7f773460bb"
 dependencies = [
  "anstream",
  "anstyle",
@@ -513,12 +513,9 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a430a770ebd84726f584a90ee7f020d28db52c6d02138900f22341f866d39c"
-dependencies = [
- "cfg-if 1.0.0",
-]
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
 
 [[package]]
 name = "ctrlc"
@@ -932,9 +929,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -1065,9 +1062,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1099,9 +1096,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "linked-hash-map"
@@ -1343,7 +1340,7 @@ version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
  "serde",
 ]
 
@@ -1395,7 +1392,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "concurrent-queue",
  "pin-project-lite",
- "rustix 0.38.28",
+ "rustix 0.38.30",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -1621,9 +1618,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.28"
+version = "0.38.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
 dependencies = [
  "bitflags 2.4.1",
  "errno",
@@ -1634,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6b63262c9fcac8659abfaa96cac103d28166d3ff3eaf8f412e19f3ae9e5a48"
+checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
 dependencies = [
  "log",
  "ring 0.17.7",
@@ -1653,7 +1650,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
 dependencies = [
- "base64 0.21.6",
+ "base64 0.21.7",
  "rustls-pki-types",
 ]
 
@@ -1956,7 +1953,7 @@ name = "trust0-client"
 version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
- "base64 0.21.6",
+ "base64 0.21.7",
  "clap",
  "ctrlc",
  "derive_builder",
@@ -1987,7 +1984,7 @@ name = "trust0-common"
 version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
- "base64 0.21.6",
+ "base64 0.21.7",
  "clap",
  "dotenvy",
  "futures-util",
@@ -2000,6 +1997,7 @@ dependencies = [
  "rcgen",
  "regex",
  "ring 0.17.7",
+ "rpassword",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
@@ -2098,9 +2096,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "value-bag"
-version = "1.4.3"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ce5bb364b23e66b528d03168df78b38c0f7b6fe17386928f29d5ab2e7cb2f7"
+checksum = "7cdbaf5e132e593e9fc1de6a15bbec912395b11fb9719e061cf64f804524c503"
 
 [[package]]
 name = "waker-fn"
@@ -2116,9 +2114,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -2126,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
  "bumpalo",
  "log",
@@ -2141,9 +2139,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -2153,9 +2151,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2163,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2176,15 +2174,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "web-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,9 +350,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.5"
+version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+checksum = "c79fed4cdb43e993fcdadc7e58a09fd0e3e649c4436fa11da71c9f1f3ee7feb9"
 
 [[package]]
 name = "bitflags"
@@ -1343,7 +1343,7 @@ version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.6",
  "serde",
 ]
 
@@ -1653,7 +1653,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
 dependencies = [
- "base64 0.21.5",
+ "base64 0.21.6",
  "rustls-pki-types",
 ]
 
@@ -1956,6 +1956,7 @@ name = "trust0-client"
 version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
+ "base64 0.21.6",
  "clap",
  "ctrlc",
  "derive_builder",
@@ -1966,11 +1967,13 @@ dependencies = [
  "mockall",
  "once_cell",
  "rcgen",
+ "regex",
  "ring 0.17.7",
  "rpassword",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
+ "scram",
  "sct",
  "serde",
  "serde_derive",
@@ -1984,6 +1987,7 @@ name = "trust0-common"
 version = "0.4.0-alpha"
 dependencies = [
  "anyhow",
+ "base64 0.21.6",
  "clap",
  "dotenvy",
  "futures-util",
@@ -2033,6 +2037,7 @@ dependencies = [
  "ring 0.17.7",
  "rustls",
  "rustls-pki-types",
+ "scram",
  "sct",
  "serde",
  "serde_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
 dependencies = [
  "concurrent-queue",
- "event-listener 4.0.2",
+ "event-listener 4.0.3",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
@@ -159,7 +159,7 @@ dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand 2.0.1",
- "futures-lite 2.1.0",
+ "futures-lite 2.2.0",
  "slab",
 ]
 
@@ -174,7 +174,7 @@ dependencies = [
  "async-io 2.2.2",
  "async-lock 3.2.0",
  "blocking",
- "futures-lite 2.1.0",
+ "futures-lite 2.2.0",
  "once_cell",
 ]
 
@@ -208,7 +208,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "concurrent-queue",
  "futures-io",
- "futures-lite 2.1.0",
+ "futures-lite 2.2.0",
  "parking",
  "polling 3.3.1",
  "rustix 0.38.28",
@@ -232,7 +232,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7125e42787d53db9dd54261812ef17e937c95a51e4d291373b670342fa44310c"
 dependencies = [
- "event-listener 4.0.2",
+ "event-listener 4.0.3",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "async-task"
-version = "4.6.0"
+version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d90cd0b264dfdd8eb5bad0a2c217c1f88fa96a8573f40e7b12de23fb468f46"
+checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
 
 [[package]]
 name = "atomic-waker"
@@ -344,6 +344,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
@@ -371,7 +377,7 @@ dependencies = [
  "async-task",
  "fastrand 2.0.1",
  "futures-io",
- "futures-lite 2.1.0",
+ "futures-lite 2.2.0",
  "piper",
  "tracing",
 ]
@@ -437,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.12"
+version = "4.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfab8ba68f3668e89f6ff60f5b205cea56aa7b769451a59f34b8682f51c056d"
+checksum = "52bdc885e4cacc7f7c9eedc1ef6da641603180c783c41a15c264944deeaab642"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -466,7 +472,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -675,7 +681,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -751,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "4.0.2"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "218a870470cce1469024e9fb66b901aa983929d81304a1cdb299f28118e550d5"
+checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -766,7 +772,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
 dependencies = [
- "event-listener 4.0.2",
+ "event-listener 4.0.3",
  "pin-project-lite",
 ]
 
@@ -872,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "futures-lite"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeee267a1883f7ebef3700f262d2d54de95dfaf38189015a74fdc4e0c7ad8143"
+checksum = "445ba825b27408685aaecefd65178908c36c6e96aaf6d8599419d46e624192ba"
 dependencies = [
  "fastrand 2.0.1",
  "futures-core",
@@ -891,7 +897,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1224,7 +1230,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1337,7 +1343,7 @@ version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
 dependencies = [
- "base64",
+ "base64 0.21.5",
  "serde",
 ]
 
@@ -1435,9 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.74"
+version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2de98502f212cfcea8d0bb305bd0f49d7ebdd75b64ba0a68f937d888f4e0d6db"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
@@ -1626,7 +1632,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
 dependencies = [
- "base64",
+ "base64 0.21.5",
  "rustls-pki-types",
 ]
 
@@ -1666,6 +1672,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scram"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7679a5e6b97bac99b2c208894ba0d34b17d9657f0b728c1cd3bf1c5f7f6ebe88"
+dependencies = [
+ "base64 0.13.1",
+ "rand",
+ "ring 0.16.20",
+]
+
+[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,9 +1700,9 @@ checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
 
 [[package]]
 name = "serde"
-version = "1.0.194"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b114498256798c94a0689e1a15fec6005dee8ac1f41de56404b67afc2a4b773"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
 ]
@@ -1702,20 +1719,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.194"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.110"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fbd975230bada99c8bb618e0c365c2eefa219158d5c6c29610fd09ff1833257"
+checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
 dependencies = [
  "itoa",
  "ryu",
@@ -1811,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.46"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89456b690ff72fddcecf231caedbe615c59480c93358a93dfae7fc29e3ebbf0e"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1855,7 +1872,7 @@ checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -1960,6 +1977,7 @@ dependencies = [
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
+ "scram",
  "sct",
  "serde",
  "serde_derive",
@@ -2053,9 +2071,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "value-bag"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a72e1902dde2bd6441347de2b70b7f5d59bf157c6c62f0c44572607a1d55bbe"
+checksum = "62ce5bb364b23e66b528d03168df78b38c0f7b6fe17386928f29d5ab2e7cb2f7"
 
 [[package]]
 name = "waker-fn"
@@ -2090,7 +2108,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
  "wasm-bindgen-shared",
 ]
 
@@ -2124,7 +2142,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.46",
+ "syn 2.0.48",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This is very early alpha, use with care.
 * Enhance gateway for runtime client certificate reissuance (on expiry or on demand)
 * Incorporate device posture trust assessment and rules processor for security enforcement
 * Build (more) testing: unit, integration, performance, ...
-* Strategize non-name resolution (DNS/hosts file/...) approach to handle client TLS hostname verification for service connections
+* Strategize non-name resolution (DNS/hosts file/...) approach to handle client hostname verification for TLS-type service connections
 * Supply more comprehensive source commenting
 * Consider supporting UDP multicast services
 * Consider gateway-to-gateway service proxy routing (reasons of proximity, security, ...)

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -31,4 +31,7 @@ trust0-common = { version = "0.4.0-alpha", path = "../common" }
 webpki-roots = "0.25"
 
 [dev-dependencies]
+base64 = "0.21.6"
 mockall = { version = "0.12.1" }
+regex = "1.10.2"
+scram = "0.6.0"

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -20,6 +20,7 @@ once_cell = "1.19.0"
 pki-types = { package = "rustls-pki-types", version = "1.0.1", features = ["std"] }
 rcgen = { version = "0.11.3", features = ["pem"], default-features = false }
 ring = "0.17.7"
+rpassword = "7.3.1"
 rustls = { version = "0.22.1", features = [ "logging" ] }
 rustls-pemfile = "2.0.0"
 sct = "0.7.1"

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -67,6 +67,8 @@ impl client_std::ClientVisitor for ClientVisitor {
         &mut self,
         tls_conn: conn_std::TlsClientConnection,
     ) -> Result<conn_std::Connection, AppError> {
+        // TODO
+        // authenticate_mfa
         let conn_visitor =
             ServerConnVisitor::new(self.app_config.clone(), self.service_mgr.clone())?;
         let connection = conn_std::Connection::new(Box::new(conn_visitor), tls_conn)?;

--- a/crates/client/src/gateway/connection.rs
+++ b/crates/client/src/gateway/connection.rs
@@ -48,7 +48,7 @@ impl conn_std::ConnectionVisitor for ServerConnVisitor {
             .unwrap()
             .write_shell_prompt(true)?;
         let stdin_connector = ShellInputReader::new();
-        ShellInputReader::spawn_line_reader(stdin_connector.clone_channel_sender());
+        stdin_connector.spawn_line_reader();
         self.stdin_connector = Some(Box::new(stdin_connector));
         Ok(())
     }

--- a/crates/client/src/gateway/controller.rs
+++ b/crates/client/src/gateway/controller.rs
@@ -1,27 +1,243 @@
 use anyhow::Result;
 use std::borrow::Borrow;
 use std::io::Write;
-use std::sync::{Arc, Mutex};
+use std::rc::Rc;
+use std::sync::{mpsc, Arc, Mutex, MutexGuard};
+use std::time::Duration;
+use trust0_common::authn::authenticator::{AuthenticatorClient, AuthnMessage, AuthnType};
+use trust0_common::authn::scram_sha256_authenticator::ScramSha256AuthenticatorClient;
 
 use crate::config::AppConfig;
+use crate::console;
 use crate::console::ShellOutputWriter;
 use crate::service::manager::{self, ServiceMgr};
 use trust0_common::control::{request, response};
 use trust0_common::error::AppError;
+use trust0_common::net::tls_client::conn_std;
+
+const AUTHN_LABEL_USERNAME: &str = "Username: ";
+const AUTHN_LABEL_PASSWORD: &str = "Password: ";
+
+const AUTHN_RESPONSE_AUTHENTICATED: &str = "Authenticated";
+const AUTHN_RESPONSE_UNAUTHENTICATED: &str = "Unauthenticated";
+const AUTHN_RESPONSE_ERROR: &str = "Error";
+
+/// (MFA) Authentication context
+struct AuthnContext {
+    authenticator: Option<Box<dyn AuthenticatorClient>>,
+    authn_type: AuthnType,
+    username: Option<String>,
+}
 
 /// Process control plane commands (validate requests, parse gateway control plane responses).
 pub struct ControlPlane {
     processor: request::RequestProcessor,
+    event_channel_sender: Option<mpsc::Sender<conn_std::ConnectionEvent>>,
     console_shell_output: Arc<Mutex<ShellOutputWriter>>,
+    tty_echo_disabler: Arc<Mutex<bool>>,
+    authn_context: Rc<Mutex<Option<AuthnContext>>>,
+    authenticated: Rc<Mutex<bool>>,
 }
 
 impl ControlPlane {
     /// ControlPlane constructor
-    pub fn new(app_config: Arc<AppConfig>) -> Self {
+    pub fn new(app_config: Arc<AppConfig>, tty_echo_disabler: Arc<Mutex<bool>>) -> Self {
         Self {
             processor: request::RequestProcessor::new(),
+            event_channel_sender: None,
             console_shell_output: app_config.console_shell_output.clone(),
+            tty_echo_disabler,
+            authn_context: Rc::new(Mutex::new(None)),
+            authenticated: Rc::new(Mutex::new(false)),
         }
+    }
+
+    /// Send control plane connection event message
+    fn send_connection_event_message(
+        &self,
+        message: conn_std::ConnectionEvent,
+    ) -> Result<(), AppError> {
+        let event_sender = self.event_channel_sender.as_ref().unwrap();
+
+        if let Err(err) = event_sender.send(message).map_err(|err| {
+            AppError::GenWithMsgAndErr("Error sending connection event".to_string(), Box::new(err))
+        }) {
+            let _ = event_sender.send(conn_std::ConnectionEvent::Closing);
+
+            return Err(err);
+        }
+
+        Ok(())
+    }
+
+    /// Process authentication message
+    fn process_authn_message(&self, authn_msg: Option<AuthnMessage>) -> Result<(), AppError> {
+        // Process authentication message
+        let mut authn_context = self.authn_context.lock().unwrap();
+        let authn_type = authn_context.as_ref().unwrap().authn_type.clone();
+
+        let (console_output_text, response_authn_msg, authn_complete) = match authn_type {
+            AuthnType::ScramSha256 => {
+                self.process_authn_message_for_scramsha256(&mut authn_context, authn_msg)?
+            }
+            AuthnType::Insecure => {
+                self.process_authn_message_for_insecure(&mut authn_context, authn_msg)?
+            }
+        };
+
+        // Send gateway authentication message
+        if response_authn_msg.is_some() {
+            self.send_connection_event_message(conn_std::ConnectionEvent::Write(
+                format!(
+                    r#"{} --{} "{}""#,
+                    request::PROTOCOL_REQUEST_LOGIN_DATA,
+                    request::PROTOCOL_REQUEST_LOGIN_DATA_ARG_MESSAGE,
+                    response_authn_msg
+                        .unwrap()
+                        .to_json_str()?
+                        .replace('\\', "\\\\")
+                        .replace('"', "\\\"")
+                )
+                .into_bytes(),
+            ))?;
+        }
+
+        // Display text (if required)
+        if !console_output_text.is_empty() {
+            self.console_shell_output
+                .lock()
+                .unwrap()
+                .write_all(console_output_text.as_bytes())
+                .map_err(|err| {
+                    AppError::GenWithMsgAndErr(
+                        "Error writing login label to STDOUT".to_string(),
+                        Box::new(err),
+                    )
+                })?;
+            self.console_shell_output
+                .lock()
+                .unwrap()
+                .flush()
+                .map_err(|err| {
+                    AppError::GenWithMsgAndErr(
+                        "Error flushing login label to STDOUT".to_string(),
+                        Box::new(err),
+                    )
+                })?;
+        }
+
+        if authn_complete {
+            self.console_shell_output
+                .lock()
+                .unwrap()
+                .write_shell_prompt(false)?;
+            *authn_context = None;
+        }
+
+        Ok(())
+    }
+
+    /// Process authentication message (SCRAM SHA256)
+    fn process_authn_message_for_scramsha256(
+        &self,
+        authn_context: &mut MutexGuard<Option<AuthnContext>>,
+        authn_msg: Option<AuthnMessage>,
+    ) -> Result<(String, Option<AuthnMessage>, bool), AppError> {
+        let mut console_output_text = String::new();
+        let mut response_authn_msg = None;
+        let mut authn_complete = false;
+
+        // Step 1: Prepare to receive username. Disable TTY echo for password input
+        if authn_msg.is_none() {
+            console_output_text = AUTHN_LABEL_USERNAME.to_string();
+            *self.tty_echo_disabler.lock().unwrap() = true;
+        }
+        // Step 2: Save username. Prepare to receive password
+        else if authn_context.as_ref().unwrap().username.is_none() {
+            console_output_text = AUTHN_LABEL_PASSWORD.to_string();
+            if let Some(AuthnMessage::Payload(username)) = authn_msg {
+                authn_context
+                    .as_mut()
+                    .unwrap()
+                    .username
+                    .replace(username.trim_end().to_string());
+            }
+        }
+        // Step 3: Start up authenticator with given username, password
+        else if authn_context.as_ref().unwrap().authenticator.is_none() {
+            if let Some(AuthnMessage::Payload(password)) = authn_msg {
+                let username = authn_context.as_ref().unwrap().username.as_ref().unwrap();
+                let mut authenticator = ScramSha256AuthenticatorClient::new(
+                    username,
+                    password.trim_end(),
+                    Duration::from_millis(10_000),
+                );
+                let _ = authenticator.spawn_authentication();
+                response_authn_msg = authenticator.exchange_messages(None)?;
+                authn_context
+                    .as_mut()
+                    .unwrap()
+                    .authenticator
+                    .replace(Box::new(authenticator));
+            }
+        }
+        // Steps 4,...: Exchange authentication flow messages
+        else {
+            match &authn_msg {
+                Some(AuthnMessage::Payload(_)) => {}
+                Some(AuthnMessage::Error(msg)) => {
+                    console_output_text = format!(
+                        "{}: msg={:?}{}",
+                        AUTHN_RESPONSE_ERROR,
+                        msg,
+                        console::LINE_ENDING
+                    )
+                }
+                Some(_) => {}
+                None => {}
+            }
+            response_authn_msg = authn_context
+                .as_mut()
+                .unwrap()
+                .authenticator
+                .as_mut()
+                .unwrap()
+                .exchange_messages(authn_msg)?;
+            if response_authn_msg.is_none() {
+                if authn_context
+                    .as_ref()
+                    .unwrap()
+                    .authenticator
+                    .as_ref()
+                    .unwrap()
+                    .is_authenticated()
+                {
+                    *self.authenticated.lock().unwrap() = true;
+                    console_output_text =
+                        format!("{}{}", AUTHN_RESPONSE_AUTHENTICATED, console::LINE_ENDING);
+                } else if console_output_text.is_empty() {
+                    console_output_text =
+                        format!("{}{}", AUTHN_RESPONSE_UNAUTHENTICATED, console::LINE_ENDING);
+                }
+                authn_complete = true;
+            }
+        }
+
+        Ok((console_output_text, response_authn_msg, authn_complete))
+    }
+
+    /// Process authentication message (Insecure)
+    fn process_authn_message_for_insecure(
+        &self,
+        _: &mut MutexGuard<Option<AuthnContext>>,
+        _: Option<AuthnMessage>,
+    ) -> Result<(String, Option<AuthnMessage>, bool), AppError> {
+        *self.authenticated.lock().unwrap() = true;
+        Ok((
+            format!("{}{}", AUTHN_RESPONSE_AUTHENTICATED, console::LINE_ENDING),
+            None,
+            true,
+        ))
     }
 
     /// Process 'proxies' response
@@ -49,6 +265,39 @@ impl ControlPlane {
                 Box::new(err),
             )
         })?);
+
+        Ok(())
+    }
+
+    /// Process 'login', 'login-data' responses
+    fn process_response_login_data(
+        &self,
+        gateway_response: &mut response::Response,
+    ) -> Result<(), AppError> {
+        let login_data_list =
+            response::LoginData::from_serde_value(gateway_response.data.as_ref().unwrap())?;
+
+        if login_data_list.len() != 1 {
+            return Err(AppError::General(format!(
+                "Expecting a single login data response object: data={:?}",
+                &login_data_list
+            )));
+        }
+        let login_data = login_data_list.first().unwrap();
+
+        if self.authn_context.lock().unwrap().is_none() {
+            *self.authn_context.lock().unwrap() = Some(AuthnContext {
+                authenticator: None,
+                authn_type: login_data.authn_type.clone(),
+                username: None,
+            });
+            self.process_authn_message(None)?;
+
+            gateway_response.request = request::Request::Ignore;
+        } else {
+            self.process_authn_message(login_data.message.clone())?;
+            gateway_response.request = request::Request::Ignore;
+        }
 
         Ok(())
     }
@@ -85,24 +334,33 @@ impl ControlPlane {
 }
 
 impl RequestProcessor for ControlPlane {
-    /// Validate given command request, prior to being sent to the gateway control plane
+    fn set_event_channel_sender(
+        &mut self,
+        event_channel_sender: mpsc::Sender<conn_std::ConnectionEvent>,
+    ) {
+        self.event_channel_sender = Some(event_channel_sender);
+    }
+
     fn validate_request(&mut self, command_line: &str) -> Result<request::Request, AppError> {
         let result: Result<request::Request, AppError>;
 
-        let processed_request = self.processor.parse(command_line);
-
-        match processed_request {
-            Ok(request::Request::None) => {
-                result = Ok(request::Request::None);
+        if self.authn_context.lock().unwrap().is_some() {
+            self.process_authn_message(Some(AuthnMessage::Payload(command_line.to_string())))?;
+            result = Ok(request::Request::Ignore);
+        } else {
+            let processed_request = self.processor.parse(command_line);
+            match processed_request {
+                Ok(request::Request::None) => {
+                    result = Ok(request::Request::None);
+                }
+                Err(err) => result = Err(err),
+                _ => result = Ok(processed_request.unwrap().clone()),
             }
-            Err(err) => result = Err(err),
-            _ => result = Ok(processed_request.unwrap().clone()),
         }
 
         result
     }
 
-    /// Process gateway response data
     fn process_response(
         &mut self,
         service_mgr: &Arc<Mutex<dyn ServiceMgr>>,
@@ -113,6 +371,12 @@ impl RequestProcessor for ControlPlane {
 
         if gateway_response.code == response::CODE_OK {
             match gateway_response.request.borrow() {
+                request::Request::Login => {
+                    self.process_response_login_data(&mut gateway_response)?;
+                }
+                request::Request::LoginData { message: _ } => {
+                    self.process_response_login_data(&mut gateway_response)?;
+                }
                 request::Request::Proxies => {
                     self.process_response_proxies(service_mgr, &mut gateway_response)?;
                 }
@@ -127,6 +391,10 @@ impl RequestProcessor for ControlPlane {
                 }
                 _ => {}
             }
+        }
+
+        if request::Request::Ignore == gateway_response.request {
+            return Ok(gateway_response);
         }
 
         // Write response to REPL shell
@@ -156,6 +424,12 @@ impl RequestProcessor for ControlPlane {
 }
 
 pub trait RequestProcessor {
+    /// Accept a connection event channel sender object
+    fn set_event_channel_sender(
+        &mut self,
+        event_channel_sender: mpsc::Sender<conn_std::ConnectionEvent>,
+    );
+
     /// Validate given command request, prior to being sent to the gateway control plane
     fn validate_request(&mut self, command_line: &str) -> Result<request::Request, AppError>;
 
@@ -170,28 +444,58 @@ pub trait RequestProcessor {
 /// Unit tests
 #[cfg(test)]
 pub mod tests {
-
     use super::*;
     use crate::config;
     use crate::service::manager::ProxyAddrs;
     use mockall::{mock, predicate};
+    use regex::Regex;
+    use ring::digest::SHA256_OUTPUT_LEN;
     use serde_json::json;
+    use std::num::NonZeroU32;
     use std::sync::mpsc;
-    use trust0_common::control::request::Request;
+    use std::sync::mpsc::TryRecvError;
+    use trust0_common::authn::authenticator::AuthenticatorServer;
+    use trust0_common::authn::scram_sha256_authenticator::ScramSha256AuthenticatorServer;
     use trust0_common::model::service::Transport;
     use trust0_common::testutils::ChannelWriter;
     use trust0_common::{model, testutils};
 
-    // mocks
-    // =====
+    // mocks/dummies
+    // =============
 
     mock! {
         pub GwReqProcessor {}
         impl RequestProcessor for GwReqProcessor {
+            fn set_event_channel_sender(&mut self, event_channel_sender: mpsc::Sender<conn_std::ConnectionEvent>);
             fn validate_request(&mut self, command_line: &str)
-                            -> Result<request::Request, AppError>;
+                -> Result<request::Request, AppError>;
             fn process_response(&mut self, service_mgr: &Arc<Mutex<dyn ServiceMgr>>, response_line: &str)
-                            -> Result<response::Response, AppError>;
+                -> Result<response::Response, AppError>;
+        }
+    }
+
+    pub struct ExampleProvider {
+        user1_password: [u8; SHA256_OUTPUT_LEN],
+    }
+
+    impl ExampleProvider {
+        pub fn new() -> Self {
+            let pwd_iterations = NonZeroU32::new(4096).unwrap();
+            let user1_password = scram::hash_password("pass1", pwd_iterations, b"user1");
+            ExampleProvider { user1_password }
+        }
+    }
+
+    impl scram::AuthenticationProvider for ExampleProvider {
+        fn get_password_for(&self, username: &str) -> Option<scram::server::PasswordInfo> {
+            match username {
+                "user1" => Some(scram::server::PasswordInfo::new(
+                    self.user1_password.to_vec(),
+                    4096,
+                    "user1".bytes().collect(),
+                )),
+                _ => None,
+            }
         }
     }
 
@@ -199,9 +503,51 @@ pub mod tests {
     // =====
 
     #[test]
+    fn ctlplane_send_connection_event_when_no_errors() {
+        let app_config = config::tests::create_app_config(None).unwrap();
+        let event_channel = mpsc::channel();
+        let mut control_plane =
+            ControlPlane::new(Arc::new(app_config), Arc::new(Mutex::new(false)));
+        control_plane.set_event_channel_sender(event_channel.0);
+
+        if let Err(err) = control_plane
+            .send_connection_event_message(conn_std::ConnectionEvent::Write(vec![0x20]))
+        {
+            panic!("Unexpected send result: err={:?}", &err);
+        }
+
+        match event_channel.1.try_recv() {
+            Ok(msg) => match msg {
+                conn_std::ConnectionEvent::Write(data) if data == vec![0x20] => {}
+                _ => panic!("Unexpected recv result: msg={:?}", &msg),
+            },
+            Err(err) => panic!("Unexpected recv result: err={:?}", &err),
+        }
+    }
+
+    #[test]
+    fn ctlplane_send_connection_event_when_error() {
+        let app_config = config::tests::create_app_config(None).unwrap();
+        let event_channel_sender;
+        {
+            event_channel_sender = mpsc::channel().0;
+        }
+        let mut control_plane =
+            ControlPlane::new(Arc::new(app_config), Arc::new(Mutex::new(false)));
+        control_plane.set_event_channel_sender(event_channel_sender);
+
+        if let Ok(msg) = control_plane
+            .send_connection_event_message(conn_std::ConnectionEvent::Write(vec![0x20]))
+        {
+            panic!("Unexpected successful send result: msg={:?}", &msg);
+        }
+    }
+
+    #[test]
     fn ctlplane_validate_request_when_invalid_request() {
         let app_config = config::tests::create_app_config(None).unwrap();
-        let mut control_plane = ControlPlane::new(Arc::new(app_config));
+        let mut control_plane =
+            ControlPlane::new(Arc::new(app_config), Arc::new(Mutex::new(false)));
 
         let result = control_plane.validate_request("INVALID");
         match result {
@@ -218,12 +564,13 @@ pub mod tests {
     #[test]
     fn ctlplane_validate_request_when_valid_ping_request() {
         let app_config = config::tests::create_app_config(None).unwrap();
-        let mut control_plane = ControlPlane::new(Arc::new(app_config));
+        let mut control_plane =
+            ControlPlane::new(Arc::new(app_config), Arc::new(Mutex::new(false)));
 
         let result = control_plane.validate_request("ping");
         match result {
             Ok(request) => {
-                if request != Request::Ping {
+                if request != request::Request::Ping {
                     panic!("Unexpected validate request: req={:?}", request);
                 }
             }
@@ -242,7 +589,8 @@ pub mod tests {
         let app_config = config::tests::create_app_config(Some(output_writer)).unwrap();
         let service_mgr: Arc<Mutex<dyn ServiceMgr + 'static>> =
             Arc::new(Mutex::new(manager::tests::MockSvcMgr::new()));
-        let mut control_plane = ControlPlane::new(Arc::new(app_config));
+        let mut control_plane =
+            ControlPlane::new(Arc::new(app_config), Arc::new(Mutex::new(false)));
 
         let result = control_plane.process_response(&service_mgr, "INVALID");
         if let Ok(response) = &result {
@@ -256,6 +604,532 @@ pub mod tests {
     }
 
     #[test]
+    fn ctlplane_process_response_when_valid_login_flow_for_scramsha256_step1() {
+        let output_channel = mpsc::channel();
+        let output_writer = ShellOutputWriter::new(Some(Box::new(ChannelWriter {
+            channel_sender: output_channel.0,
+        })));
+        let app_config = config::tests::create_app_config(Some(output_writer)).unwrap();
+        let service_mgr: Arc<Mutex<dyn ServiceMgr + 'static>> =
+            Arc::new(Mutex::new(manager::tests::MockSvcMgr::new()));
+        let mut control_plane =
+            ControlPlane::new(Arc::new(app_config), Arc::new(Mutex::new(false)));
+        let event_channel = mpsc::channel();
+        control_plane.set_event_channel_sender(event_channel.0);
+        let response_data_str = r#"[{"authnType":"scramSha256","message":null}]"#;
+        let response_data_json = serde_json::from_str(&response_data_str).unwrap();
+
+        let result = control_plane.process_response(
+            &service_mgr,
+            &format!(
+                r#"{{"code":200,"message":null,"request":"Login","data":{}}}"#,
+                response_data_str
+            ),
+        );
+
+        match &result {
+            Ok(response) => {
+                assert_eq!(
+                    response.code, 200,
+                    "Unexpected process response code: resp={:?}",
+                    response
+                );
+                assert_eq!(
+                    response.message, None,
+                    "Unexpected process response msg: resp={:?}",
+                    response
+                );
+                assert_eq!(
+                    response.request,
+                    request::Request::Ignore,
+                    "Unexpected process response request: resp={:?}",
+                    response
+                );
+                assert_eq!(
+                    response.data,
+                    Some(response_data_json),
+                    "Unexpected process response data: resp={:?}",
+                    response
+                );
+            }
+            Err(err) => {
+                panic!("Unexpected process response result: err={:?}", err);
+            }
+        }
+
+        assert!(control_plane.authn_context.lock().unwrap().is_some());
+        assert_eq!(
+            control_plane
+                .authn_context
+                .lock()
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .authn_type,
+            AuthnType::ScramSha256
+        );
+        assert!(!*control_plane.authenticated.lock().unwrap());
+
+        match event_channel.1.try_recv() {
+            Ok(msg) => panic!("Unexpected event channel msg: msg={:?}", &msg),
+            Err(err) if TryRecvError::Empty == err => {}
+            Err(err) => panic!("Unexpected event channel result: err={:?}", &err),
+        }
+
+        let expected_data = AUTHN_LABEL_USERNAME.to_string();
+        let output_data = testutils::gather_rcvd_bytearr_channel_data(&output_channel.1);
+        assert_eq!(String::from_utf8(output_data).unwrap(), expected_data);
+    }
+
+    #[test]
+    fn ctlplane_process_response_when_valid_login_flow_for_scramsha256_step2() {
+        let output_channel = mpsc::channel();
+        let output_writer = ShellOutputWriter::new(Some(Box::new(ChannelWriter {
+            channel_sender: output_channel.0,
+        })));
+        let app_config = config::tests::create_app_config(Some(output_writer)).unwrap();
+
+        let mut control_plane =
+            ControlPlane::new(Arc::new(app_config), Arc::new(Mutex::new(false)));
+        let event_channel = mpsc::channel();
+        control_plane.set_event_channel_sender(event_channel.0);
+        *control_plane.authn_context.lock().unwrap() = Some(AuthnContext {
+            authenticator: None,
+            authn_type: AuthnType::ScramSha256,
+            username: None,
+        });
+
+        match control_plane.validate_request("user1") {
+            Ok(request) if request::Request::Ignore == request => {}
+            Ok(request) => panic!("Unexpected validate result: req={:?}", &request),
+            Err(err) => panic!("Unexpected validate result: err={:?}", &err),
+        }
+
+        assert!(control_plane.authn_context.lock().unwrap().is_some());
+        assert!(control_plane
+            .authn_context
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .username
+            .is_some());
+        assert!(!*control_plane.authenticated.lock().unwrap());
+        assert_eq!(
+            control_plane
+                .authn_context
+                .lock()
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .username
+                .as_ref()
+                .unwrap(),
+            "user1"
+        );
+
+        match event_channel.1.try_recv() {
+            Ok(msg) => panic!("Unexpected event channel msg: msg={:?}", &msg),
+            Err(err) if TryRecvError::Empty == err => {}
+            Err(err) => panic!("Unexpected event channel result: err={:?}", &err),
+        }
+
+        let expected_data = AUTHN_LABEL_PASSWORD.to_string();
+        let output_data = testutils::gather_rcvd_bytearr_channel_data(&output_channel.1);
+        assert_eq!(String::from_utf8(output_data).unwrap(), expected_data);
+    }
+
+    #[test]
+    fn ctlplane_process_response_when_valid_login_flow_for_scramsha256_step3() {
+        let output_channel = mpsc::channel();
+        let output_writer = ShellOutputWriter::new(Some(Box::new(ChannelWriter {
+            channel_sender: output_channel.0,
+        })));
+        let app_config = config::tests::create_app_config(Some(output_writer)).unwrap();
+
+        let mut control_plane =
+            ControlPlane::new(Arc::new(app_config), Arc::new(Mutex::new(false)));
+        let event_channel = mpsc::channel();
+        control_plane.set_event_channel_sender(event_channel.0);
+        *control_plane.authn_context.lock().unwrap() = Some(AuthnContext {
+            authenticator: None,
+            authn_type: AuthnType::ScramSha256,
+            username: Some("user1".to_string()),
+        });
+
+        match control_plane.process_authn_message(Some(AuthnMessage::Payload("pass1".to_string())))
+        {
+            Err(err) => panic!("Unexpected process message result: err={:?}", &err),
+            Ok(()) => {}
+        }
+
+        assert!(control_plane.authn_context.lock().unwrap().is_some());
+        assert!(control_plane
+            .authn_context
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .username
+            .is_some());
+        assert!(control_plane
+            .authn_context
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .authenticator
+            .is_some());
+        assert!(!*control_plane.authenticated.lock().unwrap());
+        assert_eq!(
+            control_plane
+                .authn_context
+                .lock()
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .username
+                .as_ref()
+                .unwrap(),
+            "user1"
+        );
+
+        match event_channel.1.try_recv() {
+            Ok(msg) => match msg {
+                conn_std::ConnectionEvent::Write(_) => {}
+                _ => panic!("Unexpected event channel msg: msg={:?}", &msg),
+            },
+            Err(err) => panic!("Unexpected event channel result: err={:?}", &err),
+        }
+
+        let expected_data: Vec<u8> = vec![];
+        let output_data = testutils::gather_rcvd_bytearr_channel_data(&output_channel.1);
+        assert_eq!(output_data, expected_data);
+    }
+
+    #[test]
+    fn ctlplane_process_response_when_valid_login_flow_for_scramsha256_final_steps() {
+        let output_channel = mpsc::channel();
+        let output_writer = ShellOutputWriter::new(Some(Box::new(ChannelWriter {
+            channel_sender: output_channel.0,
+        })));
+        let app_config = config::tests::create_app_config(Some(output_writer)).unwrap();
+        let service_mgr: Arc<Mutex<dyn ServiceMgr + 'static>> =
+            Arc::new(Mutex::new(manager::tests::MockSvcMgr::new()));
+        let login_data_payload_regex =
+            Regex::new(r#"login-data --message "[{]\\"payload\\":\\"(?<data>[\S]+)\\"}""#).unwrap();
+
+        let mut control_plane =
+            ControlPlane::new(Arc::new(app_config), Arc::new(Mutex::new(false)));
+        let event_channel = mpsc::channel();
+        control_plane.set_event_channel_sender(event_channel.0);
+        *control_plane.authn_context.lock().unwrap() = Some(AuthnContext {
+            authenticator: None,
+            authn_type: AuthnType::ScramSha256,
+            username: Some("user1".to_string()),
+        });
+
+        // Perform step 3: In - None, Out - client first msg
+        match control_plane.process_authn_message(Some(AuthnMessage::Payload("pass1".to_string())))
+        {
+            Err(err) => panic!("Unexpected process message result: step=3, err={:?}", &err),
+            Ok(()) => {}
+        }
+
+        let client_to_server_data = match event_channel.1.try_recv() {
+            Ok(msg) => match msg {
+                conn_std::ConnectionEvent::Write(data) => String::from_utf8(data).unwrap(),
+                _ => panic!("Unexpected event channel msg: step=3, msg={:?}", &msg),
+            },
+            Err(err) => panic!("Unexpected event channel result: step=3, err={:?}", &err),
+        };
+
+        let Some(captures) = login_data_payload_regex.captures(&client_to_server_data) else {
+            panic!(
+                "Unexpected client first message: msg={:?}",
+                &client_to_server_data
+            );
+        };
+        let client_to_server_data = captures["data"]
+            .to_string()
+            .replace("\\\\", "\\")
+            .replace("\\\\", "\\")
+            .replace("\\\"", "\"");
+        let client_to_server_msg = Some(AuthnMessage::Payload(client_to_server_data));
+
+        let mut auth_server =
+            ScramSha256AuthenticatorServer::new(ExampleProvider::new(), Duration::from_millis(100));
+        auth_server.spawn_authentication().unwrap();
+
+        // Perform step 4: In - server first msg, Out - client final msg
+        let server_to_client_data = match auth_server.exchange_messages(client_to_server_msg) {
+            Ok(Some(server_to_client_msg)) => {
+                if let AuthnMessage::Payload(data) = server_to_client_msg {
+                    data
+                } else {
+                    panic!(
+                        "Unexpected server response to client first msg: step=4, msg={:?}",
+                        &server_to_client_msg
+                    );
+                }
+            }
+            Ok(None) => panic!("Unexpected missing server response to client first msg: step=4"),
+            Err(err) => panic!(
+                "Unexpected server response to client first msg: step=4, err={:?}",
+                &err
+            ),
+        };
+
+        let response_data_str = format!(
+            r#"[{{"authnType":"scramSha256","message":{{"payload": "{}"}}}}]"#,
+            &server_to_client_data
+                .replace('\\', "\\\\")
+                .replace('"', "\\\"")
+        );
+        let response_data_json = serde_json::from_str(&response_data_str).unwrap();
+
+        let result = control_plane.process_response(
+            &service_mgr,
+            &format!(
+                r#"{{"code":200,"message":null,"request":{},"data":{}}}"#,
+                r#"{"LoginData":{"authnType":"scramSha256","message":{"payload":"msg1"}}}"#,
+                response_data_str
+            ),
+        );
+
+        match &result {
+            Ok(response) => {
+                assert_eq!(
+                    response.code, 200,
+                    "Unexpected process response code: step=4, resp={:?}",
+                    response
+                );
+                assert_eq!(
+                    response.message, None,
+                    "Unexpected process response msg: step=4, resp={:?}",
+                    response
+                );
+                assert_eq!(
+                    response.request,
+                    request::Request::Ignore,
+                    "Unexpected process response request: step=4, resp={:?}",
+                    response
+                );
+                assert_eq!(
+                    response.data,
+                    Some(response_data_json),
+                    "Unexpected process response data: step=4, resp={:?}",
+                    response
+                );
+            }
+            Err(err) => {
+                panic!("Unexpected process response result: step=4, err={:?}", err);
+            }
+        }
+
+        assert!(control_plane.authn_context.lock().unwrap().is_some());
+        assert!(control_plane
+            .authn_context
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .username
+            .is_some());
+        assert!(control_plane
+            .authn_context
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .authenticator
+            .is_some());
+        assert!(!*control_plane.authenticated.lock().unwrap());
+        assert_eq!(
+            control_plane
+                .authn_context
+                .lock()
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .username
+                .as_ref()
+                .unwrap(),
+            "user1"
+        );
+
+        let client_to_server_data = match event_channel.1.try_recv() {
+            Ok(msg) => match msg {
+                conn_std::ConnectionEvent::Write(data) => String::from_utf8(data).unwrap(),
+                _ => panic!("Unexpected event channel msg: step=4, msg={:?}", &msg),
+            },
+            Err(err) => panic!("Unexpected event channel result: step=4, err={:?}", &err),
+        };
+
+        let Some(captures) = login_data_payload_regex.captures(&client_to_server_data) else {
+            panic!(
+                "Unexpected client first message: step=4, msg={:?}",
+                &client_to_server_data
+            );
+        };
+        let client_to_server_data = captures["data"]
+            .to_string()
+            .replace("\\\\", "\\")
+            .replace("\\\\", "\\")
+            .replace("\\\"", "\"");
+        let client_to_server_msg = Some(AuthnMessage::Payload(client_to_server_data));
+
+        // Perform step 5: In - server final msg, Out - None
+        let server_to_client_data = match auth_server.exchange_messages(client_to_server_msg) {
+            Ok(Some(server_to_client_msg)) => {
+                if let AuthnMessage::Payload(data) = server_to_client_msg {
+                    data
+                } else {
+                    panic!(
+                        "Unexpected server response to client final msg: step=5, msg={:?}",
+                        &server_to_client_msg
+                    );
+                }
+            }
+            Ok(None) => panic!("Unexpected missing server response to client final msg: step=5"),
+            Err(err) => panic!(
+                "Unexpected server response to client final msg: step=5, err={:?}",
+                &err
+            ),
+        };
+
+        let response_data_str = format!(
+            r#"[{{"authnType":"scramSha256","message":{{"payload": "{}"}}}}]"#,
+            &server_to_client_data
+                .replace('\\', "\\\\")
+                .replace('"', "\\\"")
+        );
+        let response_data_json = serde_json::from_str(&response_data_str).unwrap();
+
+        let result = control_plane.process_response(
+            &service_mgr,
+            &format!(
+                r#"{{"code":200,"message":null,"request":{},"data":{}}}"#,
+                r#"{"LoginData":{"authnType":"scramSha256","message":{"payload":"msg1"}}}"#,
+                response_data_str
+            ),
+        );
+
+        match &result {
+            Ok(response) => {
+                assert_eq!(
+                    response.code, 200,
+                    "Unexpected process response code: step=5, resp={:?}",
+                    response
+                );
+                assert_eq!(
+                    response.message, None,
+                    "Unexpected process response msg: step=5, resp={:?}",
+                    response
+                );
+                assert_eq!(
+                    response.request,
+                    request::Request::Ignore,
+                    "Unexpected process response request: step=5, resp={:?}",
+                    response
+                );
+                assert_eq!(
+                    response.data,
+                    Some(response_data_json),
+                    "Unexpected process response data: step=5, resp={:?}",
+                    response
+                );
+            }
+            Err(err) => {
+                panic!("Unexpected process response result: step=5, err={:?}", err);
+            }
+        }
+
+        assert!(control_plane.authn_context.lock().unwrap().is_none());
+        assert!(*control_plane.authenticated.lock().unwrap());
+
+        match event_channel.1.try_recv() {
+            Ok(msg) => panic!("Unexpected successful event channel msg: msg={:?}", &msg),
+            Err(err) if TryRecvError::Empty == err => {}
+            Err(err) => panic!("Unexpected event channel result: err={:?}", &err),
+        }
+
+        let expected_data = format!(
+            "{}{}{}",
+            AUTHN_RESPONSE_AUTHENTICATED,
+            console::LINE_ENDING,
+            console::SHELL_PROMPT
+        );
+        let output_data = testutils::gather_rcvd_bytearr_channel_data(&output_channel.1);
+        assert_eq!(String::from_utf8(output_data).unwrap(), expected_data);
+    }
+
+    #[test]
+    fn ctlplane_process_response_when_valid_login_response_for_insecure_step1() {
+        let output_channel = mpsc::channel();
+        let output_writer = ShellOutputWriter::new(Some(Box::new(ChannelWriter {
+            channel_sender: output_channel.0,
+        })));
+        let app_config = config::tests::create_app_config(Some(output_writer)).unwrap();
+        let service_mgr: Arc<Mutex<dyn ServiceMgr + 'static>> =
+            Arc::new(Mutex::new(manager::tests::MockSvcMgr::new()));
+        let mut control_plane =
+            ControlPlane::new(Arc::new(app_config), Arc::new(Mutex::new(false)));
+        let response_data_str = r#"[{"authnType":"insecure","message":null}]"#;
+        let response_data_json = serde_json::from_str(&response_data_str).unwrap();
+
+        let result = control_plane.process_response(
+            &service_mgr,
+            &format!(
+                r#"{{"code":200,"message":null,"request":"Login","data":{}}}"#,
+                response_data_str
+            ),
+        );
+
+        match &result {
+            Ok(response) => {
+                assert_eq!(
+                    response.code, 200,
+                    "Unexpected process response code: resp={:?}",
+                    response
+                );
+                assert_eq!(
+                    response.message, None,
+                    "Unexpected process response msg: resp={:?}",
+                    response
+                );
+                assert_eq!(
+                    response.request,
+                    request::Request::Ignore,
+                    "Unexpected process response request: resp={:?}",
+                    response
+                );
+                assert_eq!(
+                    response.data,
+                    Some(response_data_json),
+                    "Unexpected process response data: resp={:?}",
+                    response
+                );
+            }
+            Err(err) => {
+                panic!("Unexpected process response result: err={:?}", err);
+            }
+        }
+
+        assert!(control_plane.authn_context.lock().unwrap().is_none());
+        assert!(*control_plane.authenticated.lock().unwrap());
+
+        let expected_data = format!(
+            "{}{}{}",
+            AUTHN_RESPONSE_AUTHENTICATED,
+            console::LINE_ENDING,
+            console::SHELL_PROMPT
+        );
+        let output_data = testutils::gather_rcvd_bytearr_channel_data(&output_channel.1);
+        assert_eq!(String::from_utf8(output_data).unwrap(), expected_data);
+    }
+
+    #[test]
     fn ctlplane_process_response_when_valid_proxies_response_for_no_proxies() {
         let output_channel = mpsc::channel();
         let output_writer = ShellOutputWriter::new(Some(Box::new(ChannelWriter {
@@ -264,7 +1138,8 @@ pub mod tests {
         let app_config = config::tests::create_app_config(Some(output_writer)).unwrap();
         let service_mgr: Arc<Mutex<dyn ServiceMgr + 'static>> =
             Arc::new(Mutex::new(manager::tests::MockSvcMgr::new()));
-        let mut control_plane = ControlPlane::new(Arc::new(app_config));
+        let mut control_plane =
+            ControlPlane::new(Arc::new(app_config), Arc::new(Mutex::new(false)));
 
         let result = control_plane.process_response(
             &service_mgr,
@@ -284,7 +1159,7 @@ pub mod tests {
                 );
                 assert_eq!(
                     response.request,
-                    Request::Proxies,
+                    request::Request::Proxies,
                     "Unexpected process response request: resp={:?}",
                     response
                 );
@@ -296,7 +1171,7 @@ pub mod tests {
                 );
             }
             Err(err) => {
-                panic!("Unexpected validate result: err={:?}", err);
+                panic!("Unexpected process response result: err={:?}", err);
             }
         }
 
@@ -327,7 +1202,8 @@ pub mod tests {
             .return_once(|_| Some(ProxyAddrs(8601, "gwhost1".to_string(), 8400)));
         let service_mgr: Arc<Mutex<dyn ServiceMgr + 'static>> = Arc::new(Mutex::new(service_mgr));
 
-        let mut control_plane = ControlPlane::new(Arc::new(app_config));
+        let mut control_plane =
+            ControlPlane::new(Arc::new(app_config), Arc::new(Mutex::new(false)));
 
         let response_data_str = "[
                 {
@@ -374,7 +1250,7 @@ pub mod tests {
                 );
                 assert_eq!(
                     response.request,
-                    Request::Proxies,
+                    request::Request::Proxies,
                     "Unexpected process response request: resp={:?}",
                     response
                 );
@@ -386,7 +1262,7 @@ pub mod tests {
                 );
             }
             Err(err) => {
-                panic!("Unexpected validate result: err={:?}", err);
+                panic!("Unexpected process response result: err={:?}", err);
             }
         }
 
@@ -421,7 +1297,8 @@ pub mod tests {
             .return_once(|_, addrs| Ok(addrs.clone()));
         let service_mgr: Arc<Mutex<dyn ServiceMgr + 'static>> = Arc::new(Mutex::new(service_mgr));
 
-        let mut control_plane = ControlPlane::new(Arc::new(app_config));
+        let mut control_plane =
+            ControlPlane::new(Arc::new(app_config), Arc::new(Mutex::new(false)));
 
         let response_str = "{
               \"code\": 200,
@@ -461,7 +1338,7 @@ pub mod tests {
                 );
                 assert_eq!(
                     response.request,
-                    Request::Start {
+                    request::Request::Start {
                         service_name: "chat-tcp".to_string(),
                         local_port: 8501
                     },
@@ -470,7 +1347,7 @@ pub mod tests {
                 );
             }
             Err(err) => {
-                panic!("Unexpected validate result: err={:?}", err);
+                panic!("Unexpected process response result: err={:?}", err);
             }
         }
 
@@ -495,7 +1372,8 @@ pub mod tests {
             .return_once(|| Ok(()));
         let service_mgr: Arc<Mutex<dyn ServiceMgr + 'static>> = Arc::new(Mutex::new(service_mgr));
 
-        let mut control_plane = ControlPlane::new(Arc::new(app_config));
+        let mut control_plane =
+            ControlPlane::new(Arc::new(app_config), Arc::new(Mutex::new(false)));
 
         let response_str = "{\"code\":200,\"message\":null,\"request\":\"Quit\",\"data\":null}";
 
@@ -515,13 +1393,13 @@ pub mod tests {
                 );
                 assert_eq!(
                     response.request,
-                    Request::Quit,
+                    request::Request::Quit,
                     "Unexpected process response request: resp={:?}",
                     response
                 );
             }
             Err(err) => {
-                panic!("Unexpected validate result: err={:?}", err);
+                panic!("Unexpected process response result: err={:?}", err);
             }
         }
 
@@ -540,7 +1418,8 @@ pub mod tests {
         let app_config = config::tests::create_app_config(Some(output_writer)).unwrap();
         let service_mgr: Arc<Mutex<dyn ServiceMgr + 'static>> =
             Arc::new(Mutex::new(manager::tests::MockSvcMgr::new()));
-        let mut control_plane = ControlPlane::new(Arc::new(app_config));
+        let mut control_plane =
+            ControlPlane::new(Arc::new(app_config), Arc::new(Mutex::new(false)));
 
         let response_str = "{\"code\":500,\"message\":\"System error encountered\",\"request\":\"Ping\",\"data\":null}";
 
@@ -561,13 +1440,13 @@ pub mod tests {
                 );
                 assert_eq!(
                     response.request,
-                    Request::Ping,
+                    request::Request::Ping,
                     "Unexpected process response request: resp={:?}",
                     response
                 );
             }
             Err(err) => {
-                panic!("Unexpected validate result: err={:?}", err);
+                panic!("Unexpected process response result: err={:?}", err);
             }
         }
 

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.76"
+base64 = "0.21.6"
 clap = { version = "4.4.11", features = [ "derive", "env" ] }
 dotenvy = "0.15.7"
 futures-util = "0.3.29"

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -24,6 +24,7 @@ ring = "0.17.7"
 rustls = { version = "0.22.1", features = [ "logging", "read_buf" ] }
 rustls-pemfile = "2.0.0"
 sct = "0.7"
+scram = "0.6.0"
 serde = { version = "*", features = ["derive"] }
 serde_derive = "*"
 serde_json = { version = "*", features = ["arbitrary_precision"] }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -22,6 +22,7 @@ pki-types = { package = "rustls-pki-types", version = "1.0.1", features = [ "std
 rcgen = { version = "0.11.3", features = ["pem"], default-features = false }
 regex = "1.10.2"
 ring = "0.17.7"
+rpassword = "7.3.1"
 rustls = { version = "0.22.1", features = [ "logging", "read_buf" ] }
 rustls-pemfile = "2.0.0"
 sct = "0.7"
@@ -41,4 +42,9 @@ mockall = "0.12.0"
 [[bin]]
 name = "trust0-client-installer"
 path = "src/bin/trust0-client-installer/main.rs"
+test = true
+
+[[bin]]
+name = "trust0-password-hasher"
+path = "src/bin/trust0-password-hasher/main.rs"
 test = true

--- a/crates/common/src/authn/authenticator.rs
+++ b/crates/common/src/authn/authenticator.rs
@@ -1,7 +1,49 @@
 use crate::error::AppError;
+use serde_derive::{Deserialize, Serialize};
+use std::fmt;
+use std::thread::JoinHandle;
 
-/// Represents authentication message in a "challenge-response" flow
-#[derive(Debug, Clone, PartialEq)]
+/// Authentication implementation types
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum AuthnType {
+    Insecure,
+    ScramSha256,
+}
+
+impl fmt::Display for AuthnType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                AuthnType::Insecure => "insecure",
+                AuthnType::ScramSha256 => "scram-sha256",
+            }
+        )
+    }
+}
+
+impl From<String> for AuthnType {
+    fn from(type_name: String) -> Self {
+        Self::from(type_name.as_str())
+    }
+}
+
+impl From<&str> for AuthnType {
+    fn from(type_name: &str) -> Self {
+        match type_name {
+            "none" => AuthnType::Insecure,
+            "insecure" => AuthnType::Insecure,
+            "scram-sha256" => AuthnType::ScramSha256,
+            _ => panic!("Invalid AuthnType: val={}", type_name),
+        }
+    }
+}
+
+/// Authentication message in a "challenge-response" flow
+#[derive(Serialize, Deserialize, Clone, PartialEq, Debug)]
+#[serde(rename_all = "camelCase")]
 pub enum AuthnMessage {
     Payload(String),
     Error(String),
@@ -9,22 +51,222 @@ pub enum AuthnMessage {
     Unauthenticated(String),
 }
 
+impl AuthnMessage {
+    /// Parse JSON string message value
+    pub fn parse_json_str(message_str: &str) -> Result<AuthnMessage, AppError> {
+        serde_json::from_str(message_str).map_err(|err| {
+            AppError::GenWithMsgAndErr(
+                format!("Failed to parse AuthnMessage JSON: val={}", message_str),
+                Box::new(err),
+            )
+        })
+    }
+
+    /// Convert message to JSON string value
+    pub fn to_json_str(&self) -> Result<String, AppError> {
+        serde_json::to_string(self).map_err(|err| {
+            AppError::GenWithMsgAndErr(
+                "Failed to create AuthnMessage JSON".to_string(),
+                Box::new(err),
+            )
+        })
+    }
+}
+
 /// Authentication flow processing for the client party
 pub trait AuthenticatorClient {
-    /// Perform complete authentication flow as is appropriate for the client
+    /// Spawn authentication flow thread (non-blocking)
+    fn spawn_authentication(&mut self) -> Option<JoinHandle<Result<AuthnMessage, AppError>>>;
+
+    /// Perform authentication flow (blocking)
     fn authenticate(&mut self) -> Result<AuthnMessage, AppError>;
+
+    /// Exchange authentication flow messages
+    /// Optionally send inbound message and optionally receive outbound message
+    fn exchange_messages(
+        &mut self,
+        inbound_msg: Option<AuthnMessage>,
+    ) -> Result<Option<AuthnMessage>, AppError>;
+
+    /// Returns authentication status
+    fn is_authenticated(&self) -> bool;
 }
 
 /// Authentication flow processing for the server party
 pub trait AuthenticatorServer {
-    /// Perform complete authentication flow as is appropriate for the server
+    /// Spawn authentication flow thread (non-blocking)
+    fn spawn_authentication(&mut self) -> Option<JoinHandle<Result<AuthnMessage, AppError>>>;
+
+    /// Perform authentication flow (blocking)
     fn authenticate(&mut self) -> Result<AuthnMessage, AppError>;
+
+    /// Exchange authentication flow messages
+    /// Optionally send inbound message and optionally receive outbound message
+    fn exchange_messages(
+        &mut self,
+        inbound_msg: Option<AuthnMessage>,
+    ) -> Result<Option<AuthnMessage>, AppError>;
+
+    /// Returns authentication status
+    fn is_authenticated(&self) -> bool;
 }
 
 /// Unit tests
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn authtype_display() {
+        assert_eq!(format!("{}", AuthnType::Insecure), "insecure");
+        assert_eq!(format!("{}", AuthnType::ScramSha256), "scram-sha256");
+    }
+
+    #[test]
+    fn authtype_from_str_when_none_val() {
+        assert_eq!(
+            <String as Into<AuthnType>>::into("none".to_string()),
+            AuthnType::Insecure
+        );
+        assert_eq!(<&str as Into<AuthnType>>::into("none"), AuthnType::Insecure);
+    }
+
+    #[test]
+    fn authtype_from_str_when_insecure_val() {
+        assert_eq!(
+            <String as Into<AuthnType>>::into("insecure".to_string()),
+            AuthnType::Insecure
+        );
+        assert_eq!(
+            <&str as Into<AuthnType>>::into("insecure"),
+            AuthnType::Insecure
+        );
+    }
+
+    #[test]
+    fn authtype_from_str_when_scramsha256_val() {
+        assert_eq!(
+            <String as Into<AuthnType>>::into("scram-sha256".to_string()),
+            AuthnType::ScramSha256
+        );
+        assert_eq!(
+            <&str as Into<AuthnType>>::into("scram-sha256"),
+            AuthnType::ScramSha256
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn authtype_from_str_when_invalid_val() {
+        let _authn_type: AuthnType = "invalid".into();
+    }
+
+    #[test]
+    fn authnmsg_parse_json_str_when_valid_payload_msg() {
+        let json_str = r#"{"payload":"data1"}"#;
+        match AuthnMessage::parse_json_str(json_str) {
+            Ok(msg) => assert_eq!(msg, AuthnMessage::Payload("data1".to_string())),
+            Err(err) => panic!("Unexpected result: err={:?}", &err),
+        }
+    }
+
+    #[test]
+    fn authnmsg_parse_json_str_when_invalid_payload_msg() {
+        let json_str = r#"{"payload":"data1""#;
+        if let Ok(msg) = AuthnMessage::parse_json_str(json_str) {
+            panic!("Unexpected successful result: msg={:?}", &msg);
+        }
+    }
+
+    #[test]
+    fn authnmsg_parse_json_str_when_valid_error_msg() {
+        let json_str = r#"{"error":"msg1"}"#;
+        match AuthnMessage::parse_json_str(json_str) {
+            Ok(msg) => assert_eq!(msg, AuthnMessage::Error("msg1".to_string())),
+            Err(err) => panic!("Unexpected result: err={:?}", &err),
+        }
+    }
+
+    #[test]
+    fn authnmsg_parse_json_str_when_invalid_error_msg() {
+        let json_str = r#"{"error":"msg1""#;
+        if let Ok(msg) = AuthnMessage::parse_json_str(json_str) {
+            panic!("Unexpected successful result: msg={:?}", &msg);
+        }
+    }
+
+    #[test]
+    fn authnmsg_parse_json_str_when_valid_authenticated_msg() {
+        let json_str = r#""authenticated""#;
+        if let Err(err) = AuthnMessage::parse_json_str(json_str) {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+    }
+
+    #[test]
+    fn authnmsg_parse_json_str_when_invalid_authenticated_msg() {
+        let json_str = r#""authenticated": true""#;
+        if let Ok(msg) = AuthnMessage::parse_json_str(json_str) {
+            panic!("Unexpected successful result: msg={:?}", &msg);
+        }
+    }
+
+    #[test]
+    fn authnmsg_parse_json_str_when_valid_unauthenticated_msg() {
+        let json_str = r#"{"unauthenticated":"msg1"}"#;
+        match AuthnMessage::parse_json_str(json_str) {
+            Ok(msg) => assert_eq!(msg, AuthnMessage::Unauthenticated("msg1".to_string())),
+            Err(err) => panic!("Unexpected result: err={:?}", &err),
+        }
+    }
+
+    #[test]
+    fn authnmsg_parse_json_str_when_invalid_unauthenticated_msg() {
+        let json_str = r#"{"unauthenticated":"msg1""#;
+        if let Ok(msg) = AuthnMessage::parse_json_str(json_str) {
+            panic!("Unexpected successful result: msg={:?}", &msg);
+        }
+    }
+
+    #[test]
+    fn authnmsg_to_json_str_when_payload_msg() {
+        let expected_json_str = r#"{"payload":"data1"}"#;
+        let authn_msg = AuthnMessage::Payload("data1".to_string());
+        match authn_msg.to_json_str() {
+            Ok(json_str) => assert_eq!(json_str, expected_json_str),
+            Err(err) => panic!("Unexpected result: err={:?}", &err),
+        }
+    }
+
+    #[test]
+    fn authnmsg_to_json_str_when_error_msg() {
+        let expected_json_str = r#"{"error":"msg1"}"#;
+        let authn_msg = AuthnMessage::Error("msg1".to_string());
+        match authn_msg.to_json_str() {
+            Ok(json_str) => assert_eq!(json_str, expected_json_str),
+            Err(err) => panic!("Unexpected result: err={:?}", &err),
+        }
+    }
+
+    #[test]
+    fn authnmsg_to_json_str_when_authenticated_msg() {
+        let expected_json_str = r#""authenticated""#;
+        let authn_msg = AuthnMessage::Authenticated;
+        match authn_msg.to_json_str() {
+            Ok(json_str) => assert_eq!(json_str, expected_json_str),
+            Err(err) => panic!("Unexpected result: err={:?}", &err),
+        }
+    }
+
+    #[test]
+    fn authnmsg_to_json_str_when_unauthenticated_msg() {
+        let expected_json_str = r#"{"unauthenticated":"msg1"}"#;
+        let authn_msg = AuthnMessage::Unauthenticated("msg1".to_string());
+        match authn_msg.to_json_str() {
+            Ok(json_str) => assert_eq!(json_str, expected_json_str),
+            Err(err) => panic!("Unexpected result: err={:?}", &err),
+        }
+    }
 
     #[test]
     fn authnstatus_construction() {

--- a/crates/common/src/authn/authenticator.rs
+++ b/crates/common/src/authn/authenticator.rs
@@ -1,0 +1,51 @@
+use crate::error::AppError;
+
+/// Represents authentication message in a "challenge-response" flow
+#[derive(Debug, Clone, PartialEq)]
+pub enum AuthnMessage {
+    Payload(String),
+    Error(String),
+    Authenticated,
+    Unauthenticated(String),
+}
+
+/// Authentication flow processing for the client party
+pub trait AuthenticatorClient {
+    /// Perform complete authentication flow as is appropriate for the client
+    fn authenticate(&mut self) -> Result<AuthnMessage, AppError>;
+}
+
+/// Authentication flow processing for the server party
+pub trait AuthenticatorServer {
+    /// Perform complete authentication flow as is appropriate for the server
+    fn authenticate(&mut self) -> Result<AuthnMessage, AppError>;
+}
+
+/// Unit tests
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn authnstatus_construction() {
+        let status = AuthnMessage::Payload("text".to_string());
+        let AuthnMessage::Payload(_) = status else {
+            panic!("Unexpected non-payload message: msg={:?}", &status);
+        };
+
+        let status = AuthnMessage::Error("error".to_string());
+        let AuthnMessage::Error(_) = status else {
+            panic!("Unexpected non-error message: msg={:?}", &status);
+        };
+
+        let status = AuthnMessage::Authenticated;
+        let AuthnMessage::Authenticated = status else {
+            panic!("Unexpected non-auth message: msg={:?}", &status);
+        };
+
+        let status = AuthnMessage::Unauthenticated("not allowed".to_string());
+        let AuthnMessage::Unauthenticated(_) = status else {
+            panic!("Unexpected non-unauth status: msg={:?}", &status);
+        };
+    }
+}

--- a/crates/common/src/authn/insecure_authenticator.rs
+++ b/crates/common/src/authn/insecure_authenticator.rs
@@ -1,5 +1,6 @@
 use crate::authn::authenticator::{AuthenticatorClient, AuthenticatorServer, AuthnMessage};
 use crate::error::AppError;
+use std::thread::JoinHandle;
 
 /// A client authenticator that always indicates successful authentication
 pub struct InsecureAuthenticatorClient;
@@ -12,8 +13,29 @@ impl InsecureAuthenticatorClient {
 }
 
 impl AuthenticatorClient for InsecureAuthenticatorClient {
+    fn spawn_authentication(&mut self) -> Option<JoinHandle<Result<AuthnMessage, AppError>>> {
+        None
+    }
+
     fn authenticate(&mut self) -> Result<AuthnMessage, AppError> {
         Ok(AuthnMessage::Authenticated)
+    }
+
+    fn exchange_messages(
+        &mut self,
+        _inbound_msg: Option<AuthnMessage>,
+    ) -> Result<Option<AuthnMessage>, AppError> {
+        Ok(Some(AuthnMessage::Authenticated))
+    }
+
+    fn is_authenticated(&self) -> bool {
+        true
+    }
+}
+
+impl Default for InsecureAuthenticatorClient {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -28,8 +50,29 @@ impl InsecureAuthenticatorServer {
 }
 
 impl AuthenticatorServer for InsecureAuthenticatorServer {
+    fn spawn_authentication(&mut self) -> Option<JoinHandle<Result<AuthnMessage, AppError>>> {
+        None
+    }
+
     fn authenticate(&mut self) -> Result<AuthnMessage, AppError> {
         Ok(AuthnMessage::Authenticated)
+    }
+
+    fn exchange_messages(
+        &mut self,
+        _inbound_msg: Option<AuthnMessage>,
+    ) -> Result<Option<AuthnMessage>, AppError> {
+        Ok(Some(AuthnMessage::Authenticated))
+    }
+
+    fn is_authenticated(&self) -> bool {
+        true
+    }
+}
+
+impl Default for InsecureAuthenticatorServer {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -44,6 +87,13 @@ mod test {
     }
 
     #[test]
+    fn insecurecli_spawn_authentication() {
+        let mut auth_client = InsecureAuthenticatorClient;
+        let message = auth_client.spawn_authentication();
+        assert!(message.is_none());
+    }
+
+    #[test]
     fn insecurecli_authenticate() {
         let mut auth_client = InsecureAuthenticatorClient;
         let message = auth_client.authenticate();
@@ -53,8 +103,32 @@ mod test {
     }
 
     #[test]
+    fn insecurecli_exchange_messages() {
+        let mut auth_client = InsecureAuthenticatorClient;
+        let message =
+            auth_client.exchange_messages(Some(AuthnMessage::Payload("data".to_string())));
+        assert!(message.is_ok());
+        let message = message.unwrap();
+        assert!(message.is_some());
+        assert_eq!(message.unwrap(), AuthnMessage::Authenticated);
+    }
+
+    #[test]
+    fn insecurecli_is_authenticated() {
+        let auth_client = InsecureAuthenticatorClient;
+        assert!(auth_client.is_authenticated());
+    }
+
+    #[test]
     fn insecuresvr_new() {
         let _ = InsecureAuthenticatorServer::new();
+    }
+
+    #[test]
+    fn insecuresvr_spawn_authentication() {
+        let mut auth_server = InsecureAuthenticatorServer;
+        let message = auth_server.spawn_authentication();
+        assert!(message.is_none());
     }
 
     #[test]
@@ -64,5 +138,22 @@ mod test {
         assert!(message.is_ok());
         let message = message.unwrap();
         assert_eq!(message, AuthnMessage::Authenticated);
+    }
+
+    #[test]
+    fn insecuresvr_exchange_messages() {
+        let mut auth_server = InsecureAuthenticatorServer;
+        let message =
+            auth_server.exchange_messages(Some(AuthnMessage::Payload("data".to_string())));
+        assert!(message.is_ok());
+        let message = message.unwrap();
+        assert!(message.is_some());
+        assert_eq!(message.unwrap(), AuthnMessage::Authenticated);
+    }
+
+    #[test]
+    fn insecuresvr_is_authenticated() {
+        let auth_client = InsecureAuthenticatorClient;
+        assert!(auth_client.is_authenticated());
     }
 }

--- a/crates/common/src/authn/insecure_authenticator.rs
+++ b/crates/common/src/authn/insecure_authenticator.rs
@@ -1,0 +1,68 @@
+use crate::authn::authenticator::{AuthenticatorClient, AuthenticatorServer, AuthnMessage};
+use crate::error::AppError;
+
+/// A client authenticator that always indicates successful authentication
+pub struct InsecureAuthenticatorClient;
+
+impl InsecureAuthenticatorClient {
+    /// InsecureAuthenticatorClient constructor
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl AuthenticatorClient for InsecureAuthenticatorClient {
+    fn authenticate(&mut self) -> Result<AuthnMessage, AppError> {
+        Ok(AuthnMessage::Authenticated)
+    }
+}
+
+/// A server authenticator that always indicates successful authentication
+pub struct InsecureAuthenticatorServer;
+
+impl InsecureAuthenticatorServer {
+    /// InsecureAuthenticatorServer constructor
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl AuthenticatorServer for InsecureAuthenticatorServer {
+    fn authenticate(&mut self) -> Result<AuthnMessage, AppError> {
+        Ok(AuthnMessage::Authenticated)
+    }
+}
+
+/// Unit tests
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn insecurecli_new() {
+        let _ = InsecureAuthenticatorClient::new();
+    }
+
+    #[test]
+    fn insecurecli_authenticate() {
+        let mut auth_client = InsecureAuthenticatorClient;
+        let message = auth_client.authenticate();
+        assert!(message.is_ok());
+        let message = message.unwrap();
+        assert_eq!(message, AuthnMessage::Authenticated);
+    }
+
+    #[test]
+    fn insecuresvr_new() {
+        let _ = InsecureAuthenticatorServer::new();
+    }
+
+    #[test]
+    fn insecuresvr_authenticate() {
+        let mut auth_server = InsecureAuthenticatorServer;
+        let message = auth_server.authenticate();
+        assert!(message.is_ok());
+        let message = message.unwrap();
+        assert_eq!(message, AuthnMessage::Authenticated);
+    }
+}

--- a/crates/common/src/authn/mod.rs
+++ b/crates/common/src/authn/mod.rs
@@ -1,0 +1,3 @@
+pub mod authenticator;
+pub mod insecure_authenticator;
+pub mod scram_sha256_authenticator;

--- a/crates/common/src/authn/scram_sha256_authenticator.rs
+++ b/crates/common/src/authn/scram_sha256_authenticator.rs
@@ -273,7 +273,7 @@ impl AuthenticatorClient for ScramSha256AuthenticatorClient {
             .client_response_receiver
             .as_ref()
             .unwrap()
-            .recv_timeout(Duration::from_millis(100))
+            .recv_timeout(Duration::from_millis(150))
         {
             Ok(msg) => return Ok(Some(msg)),
             Err(RecvTimeoutError::Disconnected) => return Ok(None),
@@ -524,7 +524,7 @@ where
             .server_response_receiver
             .as_ref()
             .unwrap()
-            .recv_timeout(Duration::from_millis(100))
+            .recv_timeout(Duration::from_millis(150))
         {
             Ok(msg) => return Ok(Some(msg)),
             Err(RecvTimeoutError::Disconnected) => return Ok(None),
@@ -593,7 +593,7 @@ pub mod test {
         }
     }
 
-    impl scram::AuthenticationProvider for ExampleProvider {
+    impl AuthenticationProvider for ExampleProvider {
         fn get_password_for(&self, username: &str) -> Option<scram::server::PasswordInfo> {
             match username {
                 "user1" => Some(scram::server::PasswordInfo::new(
@@ -627,7 +627,7 @@ pub mod test {
         let mut auth_client = ScramSha256AuthenticatorClient::new(
             &request_username,
             &request_password,
-            Duration::from_millis(100),
+            Duration::from_millis(150),
         );
         let client_authenticated = auth_client.authenticated.clone();
         let tester_to_client_send = auth_client.server_response_sender.take().unwrap();
@@ -641,7 +641,7 @@ pub mod test {
 
         // Spawn server thread
         let mut auth_server =
-            ScramSha256AuthenticatorServer::new(ExampleProvider::new(), Duration::from_millis(100));
+            ScramSha256AuthenticatorServer::new(ExampleProvider::new(), Duration::from_millis(150));
         let server_authenticated = auth_server.authenticated.clone();
         let tester_to_server_send = auth_server.client_response_sender.take().unwrap();
         let server_to_tester_recv = auth_server.server_response_receiver.take().unwrap();
@@ -678,7 +678,7 @@ pub mod test {
     #[test]
     fn scramsha256cli_new() {
         let auth_client =
-            ScramSha256AuthenticatorClient::new("user1", "pass1", Duration::from_millis(100));
+            ScramSha256AuthenticatorClient::new("user1", "pass1", Duration::from_millis(150));
         assert_eq!(auth_client.username, "user1");
         assert_eq!(auth_client.password, "pass1");
         assert_eq!(
@@ -690,7 +690,7 @@ pub mod test {
     #[test]
     fn scramsha256svr_new() {
         let auth_server =
-            ScramSha256AuthenticatorServer::new(ExampleProvider::new(), Duration::from_millis(100));
+            ScramSha256AuthenticatorServer::new(ExampleProvider::new(), Duration::from_millis(150));
         assert_eq!(
             *auth_server.state.clone().lock().unwrap(),
             ServerStateFlow::New
@@ -712,7 +712,7 @@ pub mod test {
             _server_to_tester_send,
         ) = start_auth_flow("userX", "pass1");
 
-        thread::sleep(Duration::from_millis(20));
+        thread::sleep(Duration::from_millis(40));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientInitialSent
@@ -739,7 +739,7 @@ pub mod test {
         };
         tester_to_server_send.send(c2s_msg).unwrap();
 
-        thread::sleep(Duration::from_millis(20));
+        thread::sleep(Duration::from_millis(40));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientInitialSent
@@ -766,7 +766,7 @@ pub mod test {
         };
         tester_to_client_send.send(s2c_msg).unwrap();
 
-        thread::sleep(Duration::from_millis(20));
+        thread::sleep(Duration::from_millis(40));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientInitialSent
@@ -806,7 +806,7 @@ pub mod test {
             _server_to_tester_send,
         ) = start_auth_flow("user1", "passX");
 
-        thread::sleep(Duration::from_millis(20));
+        thread::sleep(Duration::from_millis(40));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientInitialSent
@@ -833,7 +833,7 @@ pub mod test {
         };
         tester_to_server_send.send(c2s_msg).unwrap();
 
-        thread::sleep(Duration::from_millis(20));
+        thread::sleep(Duration::from_millis(40));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientInitialSent
@@ -863,7 +863,7 @@ pub mod test {
         };
         tester_to_client_send.send(s2c_msg).unwrap();
 
-        thread::sleep(Duration::from_millis(20));
+        thread::sleep(Duration::from_millis(40));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientResponseSent
@@ -893,7 +893,7 @@ pub mod test {
         };
         tester_to_server_send.send(c2s_msg).unwrap();
 
-        thread::sleep(Duration::from_millis(20));
+        thread::sleep(Duration::from_millis(40));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientResponseSent
@@ -923,7 +923,7 @@ pub mod test {
         };
         tester_to_client_send.send(s2c_msg).unwrap();
 
-        thread::sleep(Duration::from_millis(20));
+        thread::sleep(Duration::from_millis(40));
         assert!(!*client_authenticated.lock().unwrap());
         assert!(!*server_authenticated.lock().unwrap());
 
@@ -955,7 +955,7 @@ pub mod test {
             _server_to_tester_send,
         ) = start_auth_flow("user1", "pass1");
 
-        thread::sleep(Duration::from_millis(20));
+        thread::sleep(Duration::from_millis(40));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientInitialSent
@@ -982,7 +982,7 @@ pub mod test {
         };
         tester_to_server_send.send(c2s_msg).unwrap();
 
-        thread::sleep(Duration::from_millis(20));
+        thread::sleep(Duration::from_millis(40));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientInitialSent
@@ -1012,7 +1012,7 @@ pub mod test {
         };
         tester_to_client_send.send(s2c_msg).unwrap();
 
-        thread::sleep(Duration::from_millis(20));
+        thread::sleep(Duration::from_millis(40));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientResponseSent
@@ -1042,7 +1042,7 @@ pub mod test {
         };
         tester_to_server_send.send(c2s_msg).unwrap();
 
-        thread::sleep(Duration::from_millis(20));
+        thread::sleep(Duration::from_millis(40));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientResponseSent
@@ -1072,7 +1072,7 @@ pub mod test {
         };
         tester_to_client_send.send(s2c_msg).unwrap();
 
-        thread::sleep(Duration::from_millis(20));
+        thread::sleep(Duration::from_millis(40));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ServerFinalRecvd
@@ -1112,7 +1112,7 @@ pub mod test {
             _server_to_tester_send,
         ) = start_auth_flow("user1", "pass1");
 
-        thread::sleep(Duration::from_millis(20));
+        thread::sleep(Duration::from_millis(40));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientInitialSent
@@ -1141,7 +1141,7 @@ pub mod test {
             .send(AuthnMessage::Error("wrong".to_string()))
             .unwrap();
 
-        thread::sleep(Duration::from_millis(20));
+        thread::sleep(Duration::from_millis(40));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientInitialSent
@@ -1169,9 +1169,9 @@ pub mod test {
     #[test]
     fn scramsha256_spawn_authentication_flow_when_valid_credentials() {
         let mut auth_client =
-            ScramSha256AuthenticatorClient::new("user1", "pass1", Duration::from_millis(100));
+            ScramSha256AuthenticatorClient::new("user1", "pass1", Duration::from_millis(150));
         let mut auth_server =
-            ScramSha256AuthenticatorServer::new(ExampleProvider::new(), Duration::from_millis(100));
+            ScramSha256AuthenticatorServer::new(ExampleProvider::new(), Duration::from_millis(150));
 
         let auth_client_handle = auth_client.spawn_authentication();
         let auth_server_handle = auth_server.spawn_authentication();
@@ -1179,7 +1179,7 @@ pub mod test {
         assert!(auth_client_handle.is_some());
         assert!(auth_server_handle.is_some());
 
-        thread::sleep(Duration::from_millis(20));
+        thread::sleep(Duration::from_millis(40));
         assert_eq!(
             *auth_client.state.lock().unwrap(),
             ClientStateFlow::ClientInitialSent
@@ -1224,6 +1224,7 @@ pub mod test {
             ),
         };
 
+        thread::sleep(Duration::from_millis(40));
         assert_eq!(
             *auth_client.state.lock().unwrap(),
             ClientStateFlow::ClientInitialSent
@@ -1253,6 +1254,7 @@ pub mod test {
             ),
         };
 
+        thread::sleep(Duration::from_millis(40));
         assert_eq!(
             *auth_client.state.lock().unwrap(),
             ClientStateFlow::ClientResponseSent
@@ -1282,6 +1284,7 @@ pub mod test {
             ),
         };
 
+        thread::sleep(Duration::from_millis(40));
         assert_eq!(
             *auth_client.state.lock().unwrap(),
             ClientStateFlow::ClientResponseSent
@@ -1302,6 +1305,7 @@ pub mod test {
             ),
         }
 
+        thread::sleep(Duration::from_millis(40));
         assert_eq!(
             *auth_client.state.lock().unwrap(),
             ClientStateFlow::ServerFinalRecvd
@@ -1321,9 +1325,9 @@ pub mod test {
     fn scramsha256_spawn_authentication_flow_when_valid_credentials_but_exceed_server_channel_timeout(
     ) {
         let mut auth_client =
-            ScramSha256AuthenticatorClient::new("user1", "pass1", Duration::from_millis(100));
+            ScramSha256AuthenticatorClient::new("user1", "pass1", Duration::from_millis(150));
         let mut auth_server =
-            ScramSha256AuthenticatorServer::new(ExampleProvider::new(), Duration::from_millis(100));
+            ScramSha256AuthenticatorServer::new(ExampleProvider::new(), Duration::from_millis(150));
 
         let auth_client_handle = auth_client.spawn_authentication();
         let auth_server_handle = auth_server.spawn_authentication();
@@ -1331,7 +1335,7 @@ pub mod test {
         assert!(auth_client_handle.is_some());
         assert!(auth_server_handle.is_some());
 
-        thread::sleep(Duration::from_millis(20));
+        thread::sleep(Duration::from_millis(40));
         assert_eq!(
             *auth_client.state.lock().unwrap(),
             ClientStateFlow::ClientInitialSent
@@ -1358,7 +1362,7 @@ pub mod test {
             ),
         };
 
-        thread::sleep(auth_server.channel_timeout.add(Duration::from_millis(20)));
+        thread::sleep(auth_server.channel_timeout.add(Duration::from_millis(40)));
 
         match auth_server.exchange_messages(Some(c2s_msg)) {
             Ok(Some(msg)) => panic!(
@@ -1376,9 +1380,9 @@ pub mod test {
     fn scramsha256_spawn_authentication_flow_when_valid_credentials_but_exceed_client_channel_timeout(
     ) {
         let mut auth_client =
-            ScramSha256AuthenticatorClient::new("user1", "pass1", Duration::from_millis(100));
+            ScramSha256AuthenticatorClient::new("user1", "pass1", Duration::from_millis(150));
         let mut auth_server =
-            ScramSha256AuthenticatorServer::new(ExampleProvider::new(), Duration::from_millis(100));
+            ScramSha256AuthenticatorServer::new(ExampleProvider::new(), Duration::from_millis(150));
 
         let auth_client_handle = auth_client.spawn_authentication();
         let auth_server_handle = auth_server.spawn_authentication();
@@ -1386,7 +1390,7 @@ pub mod test {
         assert!(auth_client_handle.is_some());
         assert!(auth_server_handle.is_some());
 
-        thread::sleep(Duration::from_millis(20));
+        thread::sleep(Duration::from_millis(40));
         assert_eq!(
             *auth_client.state.lock().unwrap(),
             ClientStateFlow::ClientInitialSent
@@ -1431,6 +1435,7 @@ pub mod test {
             ),
         };
 
+        thread::sleep(Duration::from_millis(40));
         assert_eq!(
             *auth_client.state.lock().unwrap(),
             ClientStateFlow::ClientInitialSent
@@ -1442,7 +1447,7 @@ pub mod test {
         assert!(!auth_client.is_authenticated());
         assert!(!auth_server.is_authenticated());
 
-        thread::sleep(auth_client.channel_timeout.add(Duration::from_millis(20)));
+        thread::sleep(auth_client.channel_timeout.add(Duration::from_millis(40)));
 
         match auth_client.exchange_messages(Some(s2c_msg)) {
             Ok(Some(msg)) => panic!(

--- a/crates/common/src/authn/scram_sha256_authenticator.rs
+++ b/crates/common/src/authn/scram_sha256_authenticator.rs
@@ -1,0 +1,919 @@
+use crate::authn::authenticator::{AuthenticatorClient, AuthenticatorServer, AuthnMessage};
+use crate::error::AppError;
+use scram::AuthenticationStatus;
+use std::sync::mpsc;
+
+/// Handle processing error
+fn process_error(
+    response_sender: Option<&mpsc::Sender<AuthnMessage>>,
+    app_error: Option<AppError>,
+    scram_error: Option<scram::Error>,
+) -> Result<AuthnMessage, AppError> {
+    let authn_msg = match app_error {
+        Some(err) => AuthnMessage::Error(format!("{:?}", &err)),
+        None => {
+            let error = scram_error.unwrap();
+            match &error {
+                scram::Error::InvalidServer => {
+                    AuthnMessage::Unauthenticated(format!("{:?}", &error))
+                }
+                scram::Error::Authentication(_) => {
+                    AuthnMessage::Unauthenticated(format!("{:?}", &error))
+                }
+                scram::Error::InvalidUser(_) => {
+                    AuthnMessage::Unauthenticated(format!("{:?}", &error))
+                }
+                _ => AuthnMessage::Error(format!(
+                    "SCRAM SHA256 authentication processing error: err={:?}",
+                    &error
+                )),
+            }
+        }
+    };
+
+    if response_sender.is_some() {
+        response_sender
+            .unwrap()
+            .send(authn_msg.clone())
+            .map_err(|err| {
+                AppError::GenWithMsgAndErr(
+                    "Error sending SCRAM SHA256 error message".to_string(),
+                    Box::new(err),
+                )
+            })?;
+    }
+
+    Ok(authn_msg)
+}
+
+#[cfg(test)]
+#[derive(Debug, PartialEq)]
+/// Client authentication "challenge-response" state flow
+enum ClientStateFlow {
+    New,
+    ClientInitialSent,
+    ServerChallengeRecvd,
+    ClientResponseSent,
+    ServerFinalRecvd,
+}
+
+/// Client authenticator utilizing SCRAM SHA256 SASL authentication
+pub struct ScramSha256AuthenticatorClient {
+    client_response_sender: mpsc::Sender<AuthnMessage>,
+    server_response_receiver: mpsc::Receiver<AuthnMessage>,
+    username: String,
+    password: String,
+    #[cfg(test)]
+    state: Arc<Mutex<ClientStateFlow>>,
+}
+
+impl ScramSha256AuthenticatorClient {
+    /// ScramSha256AuthenticatorClient constructor
+    pub fn new(
+        client_response_sender: mpsc::Sender<AuthnMessage>,
+        server_response_receiver: mpsc::Receiver<AuthnMessage>,
+        username: &str,
+        password: &str,
+    ) -> Self {
+        Self {
+            client_response_sender,
+            server_response_receiver,
+            username: username.to_string(),
+            password: password.to_string(),
+            #[cfg(test)]
+            state: Arc::new(Mutex::new(ClientStateFlow::New)),
+        }
+    }
+}
+
+impl AuthenticatorClient for ScramSha256AuthenticatorClient {
+    fn authenticate(&mut self) -> Result<AuthnMessage, AppError> {
+        // Process (build/send) client first auth message
+        let client_request_processor =
+            scram::ScramClient::new(&self.username, &self.password, None);
+        let (server_response_handler, client_first_msg) = client_request_processor.client_first();
+
+        self.client_response_sender
+            .send(AuthnMessage::Payload(client_first_msg.clone()))
+            .map_err(|err| {
+                AppError::GenWithMsgAndErr(
+                    format!(
+                        "Error sending SCRAM SHA256 client first message: user={}, msg={}",
+                        self.username, &client_first_msg
+                    ),
+                    Box::new(err),
+                )
+            })?;
+
+        #[cfg(test)]
+        {
+            *self.state.lock().unwrap() = ClientStateFlow::ClientInitialSent;
+        }
+
+        // Process (recv/parse) server first response
+        let server_first_msg = match self.server_response_receiver.recv() {
+            Ok(auth_msg) => match auth_msg {
+                AuthnMessage::Payload(msg) => msg,
+                _ => return Ok(auth_msg),
+            },
+            Err(err) => {
+                return process_error(
+                    Some(&self.client_response_sender),
+                    Some(AppError::GenWithMsgAndErr(
+                        format!(
+                            "Error receiving SCRAM SHA256 server first message: user={}",
+                            self.username
+                        ),
+                        Box::new(err),
+                    )),
+                    None,
+                )
+            }
+        };
+
+        #[cfg(test)]
+        {
+            *self.state.lock().unwrap() = ClientStateFlow::ServerChallengeRecvd;
+        }
+
+        let client_response_processor = match server_response_handler
+            .handle_server_first(&server_first_msg)
+        {
+            Ok(processor) => processor,
+            Err(err) => return process_error(Some(&self.client_response_sender), None, Some(err)),
+        };
+
+        // Process (build/send) client final auth message
+        let (server_response_handler, client_final_msg) = client_response_processor.client_final();
+
+        self.client_response_sender
+            .send(AuthnMessage::Payload(client_final_msg.clone()))
+            .map_err(|err| {
+                AppError::GenWithMsgAndErr(
+                    format!(
+                        "Error sending SCRAM SHA256 client final message: user={}, msg={}",
+                        self.username, &client_final_msg
+                    ),
+                    Box::new(err),
+                )
+            })?;
+
+        #[cfg(test)]
+        {
+            *self.state.lock().unwrap() = ClientStateFlow::ClientResponseSent;
+        }
+
+        // Process (recv/parse) server final response
+        let server_final_msg = match self.server_response_receiver.recv() {
+            Ok(auth_msg) => match auth_msg {
+                AuthnMessage::Payload(msg) => msg,
+                _ => return Ok(auth_msg),
+            },
+            Err(err) => {
+                return process_error(
+                    None,
+                    Some(AppError::GenWithMsgAndErr(
+                        format!(
+                            "Error receiving SCRAM SHA256 server final message: user={}",
+                            self.username
+                        ),
+                        Box::new(err),
+                    )),
+                    None,
+                )
+            }
+        };
+
+        #[cfg(test)]
+        {
+            *self.state.lock().unwrap() = ClientStateFlow::ServerFinalRecvd;
+        }
+
+        match server_response_handler.handle_server_final(&server_final_msg) {
+            Ok(()) => Ok(AuthnMessage::Authenticated),
+            Err(err) => process_error(None, None, Some(err)),
+        }
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, PartialEq)]
+/// Server authentication "challenge-response" state flow
+enum ServerStateFlow {
+    New,
+    ClientInitialRecvd,
+    ServerChallengeSent,
+    ClientResponseRecvd,
+    ServerFinalSent,
+}
+
+/// Server authenticator utilizing SCRAM SHA256 SASL authentication
+pub struct ScramSha256AuthenticatorServer<P>
+where
+    P: scram::AuthenticationProvider + Sized,
+{
+    server_response_sender: mpsc::Sender<AuthnMessage>,
+    client_response_receiver: mpsc::Receiver<AuthnMessage>,
+    auth_provider: Option<Box<P>>,
+    #[cfg(test)]
+    state: Arc<Mutex<ServerStateFlow>>,
+}
+
+impl<P> ScramSha256AuthenticatorServer<P>
+where
+    P: scram::AuthenticationProvider + Sized,
+{
+    /// ScramSha256AuthenticatorServer constructor
+    pub fn new(
+        server_response_sender: mpsc::Sender<AuthnMessage>,
+        client_response_receiver: mpsc::Receiver<AuthnMessage>,
+        auth_provider: P,
+    ) -> Self {
+        Self {
+            server_response_sender,
+            client_response_receiver,
+            auth_provider: Some(Box::new(auth_provider)),
+            #[cfg(test)]
+            state: Arc::new(Mutex::new(ServerStateFlow::New)),
+        }
+    }
+}
+
+impl<P> AuthenticatorServer for ScramSha256AuthenticatorServer<P>
+where
+    P: scram::AuthenticationProvider + Sized,
+{
+    fn authenticate(&mut self) -> Result<AuthnMessage, AppError> {
+        // Process (recv/parse) client first auth message
+        let client_first_msg = match self.client_response_receiver.recv() {
+            Ok(auth_msg) => match auth_msg {
+                AuthnMessage::Payload(msg) => msg,
+                _ => return Ok(auth_msg),
+            },
+            Err(err) => {
+                return process_error(
+                    Some(&self.server_response_sender),
+                    Some(AppError::GenWithMsgAndErr(
+                        "Error receiving SCRAM SHA256 client first message".to_string(),
+                        Box::new(err),
+                    )),
+                    None,
+                )
+            }
+        };
+
+        #[cfg(test)]
+        {
+            *self.state.lock().unwrap() = ServerStateFlow::ClientInitialRecvd;
+        }
+
+        let client_response_handler = scram::ScramServer::new(*self.auth_provider.take().unwrap());
+        let server_response_processor = match client_response_handler
+            .handle_client_first(&client_first_msg)
+        {
+            Ok(processor) => processor,
+            Err(err) => return process_error(Some(&self.server_response_sender), None, Some(err)),
+        };
+
+        // Process (build/send) server first (challenge) message
+        let (client_response_handler, server_first_msg) = server_response_processor.server_first();
+
+        self.server_response_sender
+            .send(AuthnMessage::Payload(server_first_msg.clone()))
+            .map_err(|err| {
+                AppError::GenWithMsgAndErr(
+                    format!(
+                        "Error sending SCRAM SHA256 server first message: msg={}",
+                        &server_first_msg
+                    ),
+                    Box::new(err),
+                )
+            })?;
+
+        #[cfg(test)]
+        {
+            *self.state.lock().unwrap() = ServerStateFlow::ServerChallengeSent;
+        }
+
+        // Process (recv/parse) client final response to auth challenge
+        let client_final_msg = match self.client_response_receiver.recv() {
+            Ok(auth_msg) => match auth_msg {
+                AuthnMessage::Payload(msg) => msg,
+                _ => return Ok(auth_msg),
+            },
+            Err(err) => {
+                return process_error(
+                    Some(&self.server_response_sender),
+                    Some(AppError::GenWithMsgAndErr(
+                        "Error receiving SCRAM SHA256 client final message".to_string(),
+                        Box::new(err),
+                    )),
+                    None,
+                )
+            }
+        };
+
+        #[cfg(test)]
+        {
+            *self.state.lock().unwrap() = ServerStateFlow::ClientResponseRecvd;
+        }
+
+        let server_response_processor = match client_response_handler
+            .handle_client_final(&client_final_msg)
+        {
+            Ok(processor) => processor,
+            Err(err) => return process_error(Some(&self.server_response_sender), None, Some(err)),
+        };
+
+        // Process (build/send) server final message
+        let (auth_status, server_final_msg) = server_response_processor.server_final();
+
+        self.server_response_sender
+            .send(AuthnMessage::Payload(server_final_msg.clone()))
+            .map_err(|err| {
+                AppError::GenWithMsgAndErr(
+                    format!(
+                        "Error sending SCRAM SHA256 server final message: msg={}",
+                        &server_final_msg
+                    ),
+                    Box::new(err),
+                )
+            })?;
+
+        #[cfg(test)]
+        {
+            *self.state.lock().unwrap() = ServerStateFlow::ServerFinalSent;
+        }
+
+        match auth_status {
+            AuthenticationStatus::Authenticated => Ok(AuthnMessage::Authenticated),
+            AuthenticationStatus::NotAuthenticated => Ok(AuthnMessage::Unauthenticated(
+                "Not authenticated".to_string(),
+            )),
+            AuthenticationStatus::NotAuthorized => {
+                Ok(AuthnMessage::Unauthenticated("Not authorized".to_string()))
+            }
+        }
+    }
+}
+
+/// Unit tests
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::authn::authenticator::AuthnMessage;
+    use std::sync::mpsc::TryRecvError;
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+    use std::time::Duration;
+
+    // mocks/dummies
+
+    struct ExampleProvider {
+        uname1_password: [u8; SHA256_OUTPUT_LEN],
+    }
+
+    impl ExampleProvider {
+        pub fn new() -> Self {
+            let pwd_iterations = NonZeroU32::new(4096).unwrap();
+            let uname1_password = scram::hash_password("pass1", pwd_iterations, b"salt");
+            ExampleProvider { uname1_password }
+        }
+    }
+
+    impl scram::AuthenticationProvider for ExampleProvider {
+        fn get_password_for(&self, username: &str) -> Option<scram::server::PasswordInfo> {
+            match username {
+                "uname1" => Some(scram::server::PasswordInfo::new(
+                    self.uname1_password.to_vec(),
+                    4096,
+                    "salt".bytes().collect(),
+                )),
+                _ => None,
+            }
+        }
+    }
+
+    // utils
+
+    fn start_auth_flow(
+        request_username: &str,
+        request_password: &str,
+    ) -> (
+        Arc<Mutex<ClientStateFlow>>,
+        Arc<Mutex<ServerStateFlow>>,
+        mpsc::Sender<AuthnMessage>,
+        mpsc::Receiver<AuthnMessage>,
+        mpsc::Sender<AuthnMessage>,
+        mpsc::Receiver<AuthnMessage>,
+        mpsc::Sender<AuthnMessage>,
+        mpsc::Sender<AuthnMessage>,
+    ) {
+        // Spawn client thread
+        let (tester_to_client_send, tester_to_client_recv) = mpsc::channel();
+        let (client_to_tester_send, client_to_tester_recv) = mpsc::channel();
+        let client_to_tester_send_copy = client_to_tester_send.clone();
+        let mut auth_client = ScramSha256AuthenticatorClient::new(
+            client_to_tester_send_copy,
+            tester_to_client_recv,
+            &request_username,
+            &request_password,
+        );
+        let client_state_flow = auth_client.state.clone();
+        thread::spawn(move || match auth_client.authenticate() {
+            Ok(msg) => println!("Auth client thread result: msg={:?}", &msg),
+            Err(err) => println!("Auth client thread result: err={:?}", &err),
+        });
+
+        // Spawn server thread
+        let (tester_to_server_send, tester_to_server_recv) = mpsc::channel();
+        let (server_to_tester_send, server_to_tester_recv) = mpsc::channel();
+        let server_to_tester_send_copy = server_to_tester_send.clone();
+        let mut auth_server = ScramSha256AuthenticatorServer::new(
+            server_to_tester_send_copy,
+            tester_to_server_recv,
+            ExampleProvider::new(),
+        );
+        let server_state_flow = auth_server.state.clone();
+        thread::spawn(move || match auth_server.authenticate() {
+            Ok(msg) => println!("Auth server thread result: msg={:?}", &msg),
+            Err(err) => println!("Auth server thread result: err={:?}", &err),
+        });
+
+        (
+            client_state_flow,
+            server_state_flow,
+            tester_to_client_send,
+            client_to_tester_recv,
+            tester_to_server_send,
+            server_to_tester_recv,
+            client_to_tester_send,
+            server_to_tester_send,
+        )
+    }
+
+    fn is_authn_msg_error(msg: &AuthnMessage) -> bool {
+        match msg {
+            AuthnMessage::Payload(text) => text.starts_with("e=") || text.contains(",e="),
+            AuthnMessage::Error(_) => true,
+            _ => false,
+        }
+    }
+    // tests
+
+    #[test]
+    fn scramsha256cli_new() {
+        let auth_client = ScramSha256AuthenticatorClient::new(
+            mpsc::channel().0,
+            mpsc::channel().1,
+            "uname1",
+            "pass1",
+        );
+        assert_eq!(auth_client.username, "uname1");
+        assert_eq!(auth_client.password, "pass1");
+        assert_eq!(
+            *auth_client.state.clone().lock().unwrap(),
+            ClientStateFlow::New
+        )
+    }
+
+    #[test]
+    fn scramsha256svr_new() {
+        let auth_server = ScramSha256AuthenticatorServer::new(
+            mpsc::channel().0,
+            mpsc::channel().1,
+            ExampleProvider::new(),
+        );
+        assert_eq!(
+            *auth_server.state.clone().lock().unwrap(),
+            ServerStateFlow::New
+        );
+    }
+
+    #[test]
+    fn scramsha256_authenticate_flow_when_client_first_and_invalid_username() {
+        let (
+            client_state_flow,
+            server_state_flow,
+            tester_to_client_send,
+            client_to_tester_recv,
+            tester_to_server_send,
+            server_to_tester_recv,
+            _client_to_tester_send,
+            _server_to_tester_send,
+        ) = start_auth_flow("unameX", "pass1");
+
+        thread::sleep(Duration::from_millis(10));
+        assert_eq!(
+            *client_state_flow.lock().unwrap(),
+            ClientStateFlow::ClientInitialSent
+        );
+        assert_eq!(*server_state_flow.lock().unwrap(), ServerStateFlow::New);
+
+        let c2s_msg = match client_to_tester_recv.try_recv() {
+            Ok(msg) => {
+                if let AuthnMessage::Payload(_) = msg {
+                    if is_authn_msg_error(&msg) {
+                        panic!("Unexpected client to server msg (#1): msg={:?}", &msg);
+                    }
+                    msg
+                } else {
+                    panic!("Unexpected client to server msg (#1): msg={:?}", &msg);
+                }
+            }
+            Err(err) => panic!(
+                "Unexpected client to server msg (#1) result: err={:?}",
+                &err
+            ),
+        };
+        tester_to_server_send.send(c2s_msg).unwrap();
+
+        thread::sleep(Duration::from_millis(10));
+        assert_eq!(
+            *client_state_flow.lock().unwrap(),
+            ClientStateFlow::ClientInitialSent
+        );
+        assert_eq!(
+            *server_state_flow.lock().unwrap(),
+            ServerStateFlow::ClientInitialRecvd
+        );
+
+        let s2c_msg = match server_to_tester_recv.try_recv() {
+            Ok(msg) => {
+                if let AuthnMessage::Unauthenticated(_) = msg {
+                    msg
+                } else {
+                    panic!("Unexpected server to client msg (#1): msg={:?}", &msg);
+                }
+            }
+            Err(err) => panic!(
+                "Unexpected server to client msg (#1) result: err={:?}",
+                &err
+            ),
+        };
+        tester_to_client_send.send(s2c_msg).unwrap();
+
+        thread::sleep(Duration::from_millis(10));
+        assert_eq!(
+            *client_state_flow.lock().unwrap(),
+            ClientStateFlow::ClientInitialSent
+        );
+        assert_eq!(
+            *server_state_flow.lock().unwrap(),
+            ServerStateFlow::ClientInitialRecvd
+        );
+
+        match client_to_tester_recv.try_recv() {
+            Ok(msg) => panic!("Unexpected client to server msg (#2): msg={:?}", &msg),
+            Err(err) if TryRecvError::Disconnected == err => panic!(
+                "Unexpected client to server msg (#2) result: err={:?}",
+                &err
+            ),
+            _ => {}
+        }
+
+        let _ = tester_to_client_send.send(AuthnMessage::Error("shutdown".to_string()));
+        let _ = tester_to_server_send.send(AuthnMessage::Error("shutdown".to_string()));
+    }
+
+    #[test]
+    fn scramsha256_authenticate_flow_when_client_first_and_invalid_password() {
+        let (
+            client_state_flow,
+            server_state_flow,
+            tester_to_client_send,
+            client_to_tester_recv,
+            tester_to_server_send,
+            server_to_tester_recv,
+            _client_to_tester_send,
+            _server_to_tester_send,
+        ) = start_auth_flow("uname1", "passX");
+
+        thread::sleep(Duration::from_millis(10));
+        assert_eq!(
+            *client_state_flow.lock().unwrap(),
+            ClientStateFlow::ClientInitialSent
+        );
+        assert_eq!(*server_state_flow.lock().unwrap(), ServerStateFlow::New);
+
+        let c2s_msg = match client_to_tester_recv.try_recv() {
+            Ok(msg) => {
+                if let AuthnMessage::Payload(_) = msg {
+                    if is_authn_msg_error(&msg) {
+                        panic!("Unexpected client to server msg (#1): msg={:?}", &msg);
+                    }
+                    msg
+                } else {
+                    panic!("Unexpected client to server msg (#1): msg={:?}", &msg);
+                }
+            }
+            Err(err) => panic!(
+                "Unexpected client to server msg (#1) result: err={:?}",
+                &err
+            ),
+        };
+        tester_to_server_send.send(c2s_msg).unwrap();
+
+        thread::sleep(Duration::from_millis(10));
+        assert_eq!(
+            *client_state_flow.lock().unwrap(),
+            ClientStateFlow::ClientInitialSent
+        );
+        assert_eq!(
+            *server_state_flow.lock().unwrap(),
+            ServerStateFlow::ServerChallengeSent
+        );
+
+        let s2c_msg = match server_to_tester_recv.try_recv() {
+            Ok(msg) => {
+                if let AuthnMessage::Payload(_) = msg {
+                    if is_authn_msg_error(&msg) {
+                        panic!("Unexpected server to client msg (#1): msg={:?}", &msg);
+                    }
+                    msg
+                } else {
+                    panic!("Unexpected server to client msg (#1): msg={:?}", &msg);
+                }
+            }
+            Err(err) => panic!(
+                "Unexpected server to client msg (#1) result: err={:?}",
+                &err
+            ),
+        };
+        tester_to_client_send.send(s2c_msg).unwrap();
+
+        thread::sleep(Duration::from_millis(10));
+        assert_eq!(
+            *client_state_flow.lock().unwrap(),
+            ClientStateFlow::ClientResponseSent
+        );
+        assert_eq!(
+            *server_state_flow.lock().unwrap(),
+            ServerStateFlow::ServerChallengeSent
+        );
+
+        let c2s_msg = match client_to_tester_recv.try_recv() {
+            Ok(msg) => {
+                if let AuthnMessage::Payload(_) = msg {
+                    if is_authn_msg_error(&msg) {
+                        panic!("Unexpected client to server msg (#2): msg={:?}", &msg);
+                    }
+                    msg
+                } else {
+                    panic!("Unexpected client to server msg (#2): msg={:?}", &msg);
+                }
+            }
+            Err(err) => panic!(
+                "Unexpected client to server msg (#2) result: err={:?}",
+                &err
+            ),
+        };
+        tester_to_server_send.send(c2s_msg).unwrap();
+
+        thread::sleep(Duration::from_millis(10));
+        assert_eq!(
+            *client_state_flow.lock().unwrap(),
+            ClientStateFlow::ClientResponseSent
+        );
+        assert_eq!(
+            *server_state_flow.lock().unwrap(),
+            ServerStateFlow::ServerFinalSent
+        );
+
+        let s2c_msg = match server_to_tester_recv.try_recv() {
+            Ok(msg) => {
+                if let AuthnMessage::Payload(text) = &msg {
+                    if text != "e=Invalid Password" {
+                        panic!("Unexpected server to client msg (#2): msg={:?}", &msg);
+                    }
+                    msg
+                } else {
+                    panic!("Unexpected server to client msg (#2): msg={:?}", &msg);
+                }
+            }
+            Err(err) => panic!(
+                "Unexpected server to client msg (#2) result: err={:?}",
+                &err
+            ),
+        };
+        tester_to_client_send.send(s2c_msg).unwrap();
+
+        thread::sleep(Duration::from_millis(10));
+        match client_to_tester_recv.try_recv() {
+            Ok(msg) => panic!("Unexpected client to server msg (#3): msg={:?}", &msg),
+            Err(err) if TryRecvError::Disconnected == err => panic!(
+                "Unexpected client to server msg (#3) result: err={:?}",
+                &err
+            ),
+            _ => {}
+        }
+
+        let _ = tester_to_client_send.send(AuthnMessage::Error("shutdown".to_string()));
+        let _ = tester_to_server_send.send(AuthnMessage::Error("shutdown".to_string()));
+    }
+
+    #[test]
+    fn scramsha256_authenticate_flow_when_valid_credentials() {
+        let (
+            client_state_flow,
+            server_state_flow,
+            tester_to_client_send,
+            client_to_tester_recv,
+            tester_to_server_send,
+            server_to_tester_recv,
+            _client_to_tester_send,
+            _server_to_tester_send,
+        ) = start_auth_flow("uname1", "pass1");
+
+        thread::sleep(Duration::from_millis(10));
+        assert_eq!(
+            *client_state_flow.lock().unwrap(),
+            ClientStateFlow::ClientInitialSent
+        );
+        assert_eq!(*server_state_flow.lock().unwrap(), ServerStateFlow::New);
+
+        let c2s_msg = match client_to_tester_recv.try_recv() {
+            Ok(msg) => {
+                if let AuthnMessage::Payload(_) = msg {
+                    if is_authn_msg_error(&msg) {
+                        panic!("Unexpected client to server msg (#1): msg={:?}", &msg);
+                    }
+                    msg
+                } else {
+                    panic!("Unexpected client to server msg (#1): msg={:?}", &msg);
+                }
+            }
+            Err(err) => panic!(
+                "Unexpected client to server msg (#1) result: err={:?}",
+                &err
+            ),
+        };
+        tester_to_server_send.send(c2s_msg).unwrap();
+
+        thread::sleep(Duration::from_millis(10));
+        assert_eq!(
+            *client_state_flow.lock().unwrap(),
+            ClientStateFlow::ClientInitialSent
+        );
+        assert_eq!(
+            *server_state_flow.lock().unwrap(),
+            ServerStateFlow::ServerChallengeSent
+        );
+
+        let s2c_msg = match server_to_tester_recv.try_recv() {
+            Ok(msg) => {
+                if let AuthnMessage::Payload(_) = msg {
+                    if is_authn_msg_error(&msg) {
+                        panic!("Unexpected server to client msg (#1): msg={:?}", &msg);
+                    }
+                    msg
+                } else {
+                    panic!("Unexpected server to client msg (#1): msg={:?}", &msg);
+                }
+            }
+            Err(err) => panic!(
+                "Unexpected server to client msg (#1) result: err={:?}",
+                &err
+            ),
+        };
+        tester_to_client_send.send(s2c_msg).unwrap();
+
+        thread::sleep(Duration::from_millis(10));
+        assert_eq!(
+            *client_state_flow.lock().unwrap(),
+            ClientStateFlow::ClientResponseSent
+        );
+        assert_eq!(
+            *server_state_flow.lock().unwrap(),
+            ServerStateFlow::ServerChallengeSent
+        );
+
+        let c2s_msg = match client_to_tester_recv.try_recv() {
+            Ok(msg) => {
+                if let AuthnMessage::Payload(_) = msg {
+                    if is_authn_msg_error(&msg) {
+                        panic!("Unexpected client to server msg (#2): msg={:?}", &msg);
+                    }
+                    msg
+                } else {
+                    panic!("Unexpected client to server msg (#2): msg={:?}", &msg);
+                }
+            }
+            Err(err) => panic!(
+                "Unexpected client to server msg (#2) result: err={:?}",
+                &err
+            ),
+        };
+        tester_to_server_send.send(c2s_msg).unwrap();
+
+        thread::sleep(Duration::from_millis(10));
+        assert_eq!(
+            *client_state_flow.lock().unwrap(),
+            ClientStateFlow::ClientResponseSent
+        );
+        assert_eq!(
+            *server_state_flow.lock().unwrap(),
+            ServerStateFlow::ServerFinalSent
+        );
+
+        let s2c_msg = match server_to_tester_recv.try_recv() {
+            Ok(msg) => {
+                if let AuthnMessage::Payload(_) = msg {
+                    if is_authn_msg_error(&msg) {
+                        panic!("Unexpected server to client msg (#2): msg={:?}", &msg);
+                    }
+                    msg
+                } else {
+                    panic!("Unexpected server to client msg (#2): msg={:?}", &msg);
+                }
+            }
+            Err(err) => panic!(
+                "Unexpected server to client msg (#2) result: err={:?}",
+                &err
+            ),
+        };
+        tester_to_client_send.send(s2c_msg).unwrap();
+
+        thread::sleep(Duration::from_millis(10));
+        assert_eq!(
+            *client_state_flow.lock().unwrap(),
+            ClientStateFlow::ServerFinalRecvd
+        );
+        assert_eq!(
+            *server_state_flow.lock().unwrap(),
+            ServerStateFlow::ServerFinalSent
+        );
+
+        match client_to_tester_recv.try_recv() {
+            Ok(msg) => panic!("Unexpected client to server msg (#3): msg={:?}", &msg),
+            Err(err) if TryRecvError::Disconnected == err => panic!(
+                "Unexpected client to server msg (#3) result: err={:?}",
+                &err
+            ),
+            _ => {}
+        }
+
+        let _ = tester_to_client_send.send(AuthnMessage::Error("shutdown".to_string()));
+        let _ = tester_to_server_send.send(AuthnMessage::Error("shutdown".to_string()));
+    }
+
+    #[test]
+    fn scramsha256_authenticate_flow_when_client_first_and_wrong_msg() {
+        let (
+            client_state_flow,
+            server_state_flow,
+            tester_to_client_send,
+            client_to_tester_recv,
+            tester_to_server_send,
+            server_to_tester_recv,
+            _client_to_tester_send,
+            _server_to_tester_send,
+        ) = start_auth_flow("uname1", "pass1");
+
+        thread::sleep(Duration::from_millis(10));
+        assert_eq!(
+            *client_state_flow.lock().unwrap(),
+            ClientStateFlow::ClientInitialSent
+        );
+        assert_eq!(*server_state_flow.lock().unwrap(), ServerStateFlow::New);
+
+        let _ = match client_to_tester_recv.try_recv() {
+            Ok(msg) => {
+                if let AuthnMessage::Payload(_) = msg {
+                    if is_authn_msg_error(&msg) {
+                        panic!("Unexpected client to server msg (#1): msg={:?}", &msg);
+                    }
+                    msg
+                } else {
+                    panic!("Unexpected client to server msg (#1): msg={:?}", &msg);
+                }
+            }
+            Err(err) => panic!(
+                "Unexpected client to server msg (#1) result: err={:?}",
+                &err
+            ),
+        };
+        tester_to_server_send
+            .send(AuthnMessage::Error("wrong".to_string()))
+            .unwrap();
+
+        thread::sleep(Duration::from_millis(10));
+        assert_eq!(
+            *client_state_flow.lock().unwrap(),
+            ClientStateFlow::ClientInitialSent
+        );
+        assert_eq!(*server_state_flow.lock().unwrap(), ServerStateFlow::New);
+
+        let _ = match server_to_tester_recv.try_recv() {
+            Ok(msg) => panic!("Unexpected server to client msg (#1): msg={:?}", &msg),
+            Err(err) if TryRecvError::Disconnected == err => panic!(
+                "Unexpected server to client msg (#1) result: err={:?}",
+                &err
+            ),
+            _ => {}
+        };
+
+        let _ = tester_to_client_send.send(AuthnMessage::Error("shutdown".to_string()));
+        let _ = tester_to_server_send.send(AuthnMessage::Error("shutdown".to_string()));
+    }
+}

--- a/crates/common/src/authn/scram_sha256_authenticator.rs
+++ b/crates/common/src/authn/scram_sha256_authenticator.rs
@@ -2,6 +2,8 @@ use crate::authn::authenticator::{AuthenticatorClient, AuthenticatorServer, Auth
 use crate::error::AppError;
 use scram::AuthenticationStatus;
 use std::sync::mpsc;
+#[cfg(test)]
+use std::sync::{Arc, Mutex};
 
 /// Handle processing error
 fn process_error(
@@ -362,6 +364,8 @@ where
 mod test {
     use super::*;
     use crate::authn::authenticator::AuthnMessage;
+    use ring::digest::SHA256_OUTPUT_LEN;
+    use std::num::NonZeroU32;
     use std::sync::mpsc::TryRecvError;
     use std::sync::{Arc, Mutex};
     use std::thread;
@@ -503,7 +507,7 @@ mod test {
             _server_to_tester_send,
         ) = start_auth_flow("unameX", "pass1");
 
-        thread::sleep(Duration::from_millis(10));
+        thread::sleep(Duration::from_millis(20));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientInitialSent
@@ -528,7 +532,7 @@ mod test {
         };
         tester_to_server_send.send(c2s_msg).unwrap();
 
-        thread::sleep(Duration::from_millis(10));
+        thread::sleep(Duration::from_millis(20));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientInitialSent
@@ -553,7 +557,7 @@ mod test {
         };
         tester_to_client_send.send(s2c_msg).unwrap();
 
-        thread::sleep(Duration::from_millis(10));
+        thread::sleep(Duration::from_millis(20));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientInitialSent
@@ -589,7 +593,7 @@ mod test {
             _server_to_tester_send,
         ) = start_auth_flow("uname1", "passX");
 
-        thread::sleep(Duration::from_millis(10));
+        thread::sleep(Duration::from_millis(20));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientInitialSent
@@ -614,7 +618,7 @@ mod test {
         };
         tester_to_server_send.send(c2s_msg).unwrap();
 
-        thread::sleep(Duration::from_millis(10));
+        thread::sleep(Duration::from_millis(20));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientInitialSent
@@ -642,7 +646,7 @@ mod test {
         };
         tester_to_client_send.send(s2c_msg).unwrap();
 
-        thread::sleep(Duration::from_millis(10));
+        thread::sleep(Duration::from_millis(20));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientResponseSent
@@ -670,7 +674,7 @@ mod test {
         };
         tester_to_server_send.send(c2s_msg).unwrap();
 
-        thread::sleep(Duration::from_millis(10));
+        thread::sleep(Duration::from_millis(20));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientResponseSent
@@ -698,7 +702,7 @@ mod test {
         };
         tester_to_client_send.send(s2c_msg).unwrap();
 
-        thread::sleep(Duration::from_millis(10));
+        thread::sleep(Duration::from_millis(20));
         match client_to_tester_recv.try_recv() {
             Ok(msg) => panic!("Unexpected client to server msg (#3): msg={:?}", &msg),
             Err(err) if TryRecvError::Disconnected == err => panic!(
@@ -725,7 +729,7 @@ mod test {
             _server_to_tester_send,
         ) = start_auth_flow("uname1", "pass1");
 
-        thread::sleep(Duration::from_millis(10));
+        thread::sleep(Duration::from_millis(20));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientInitialSent
@@ -750,7 +754,7 @@ mod test {
         };
         tester_to_server_send.send(c2s_msg).unwrap();
 
-        thread::sleep(Duration::from_millis(10));
+        thread::sleep(Duration::from_millis(20));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientInitialSent
@@ -778,7 +782,7 @@ mod test {
         };
         tester_to_client_send.send(s2c_msg).unwrap();
 
-        thread::sleep(Duration::from_millis(10));
+        thread::sleep(Duration::from_millis(20));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientResponseSent
@@ -806,7 +810,7 @@ mod test {
         };
         tester_to_server_send.send(c2s_msg).unwrap();
 
-        thread::sleep(Duration::from_millis(10));
+        thread::sleep(Duration::from_millis(20));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientResponseSent
@@ -834,7 +838,7 @@ mod test {
         };
         tester_to_client_send.send(s2c_msg).unwrap();
 
-        thread::sleep(Duration::from_millis(10));
+        thread::sleep(Duration::from_millis(20));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ServerFinalRecvd
@@ -870,7 +874,7 @@ mod test {
             _server_to_tester_send,
         ) = start_auth_flow("uname1", "pass1");
 
-        thread::sleep(Duration::from_millis(10));
+        thread::sleep(Duration::from_millis(20));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientInitialSent
@@ -897,7 +901,7 @@ mod test {
             .send(AuthnMessage::Error("wrong".to_string()))
             .unwrap();
 
-        thread::sleep(Duration::from_millis(10));
+        thread::sleep(Duration::from_millis(20));
         assert_eq!(
             *client_state_flow.lock().unwrap(),
             ClientStateFlow::ClientInitialSent

--- a/crates/common/src/bin/trust0-password-hasher/config.rs
+++ b/crates/common/src/bin/trust0-password-hasher/config.rs
@@ -1,0 +1,105 @@
+use std::fmt;
+
+use clap::Parser;
+
+use trust0_common::error::AppError;
+
+/// (Password-based) Authentication implementation types
+#[derive(Clone, Debug, PartialEq)]
+pub enum AuthnType {
+    ScramSha256,
+}
+
+impl fmt::Display for AuthnType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                AuthnType::ScramSha256 => "scram-sha256",
+            }
+        )
+    }
+}
+
+impl From<String> for AuthnType {
+    fn from(type_name: String) -> Self {
+        Self::from(type_name.as_str())
+    }
+}
+
+impl From<&str> for AuthnType {
+    fn from(type_name: &str) -> Self {
+        match type_name {
+            "scram-sha256" => AuthnType::ScramSha256,
+            _ => panic!("Invalid AuthnType: val={}", type_name),
+        }
+    }
+}
+
+/// Creates valid user password hashes, usable by (relevant) Trust0 authentication schemes
+#[derive(Parser, Debug)]
+#[command(author, version, long_about)]
+pub struct AppConfigArgs {
+    /// Authentication mechanism
+    /// Current schemes: 'scram-sha256': SCRAM SHA256 using credentials stored in user repository
+    #[arg(required = true, long = "authn-scheme", env, verbatim_doc_comment)]
+    pub authn_scheme: AuthnType,
+}
+
+pub struct AppConfig {
+    pub args: AppConfigArgs,
+}
+
+impl AppConfig {
+    // load config
+    pub fn new() -> Result<Self, AppError> {
+        // Parse process arguments
+        let config_args = Self::parse_config();
+
+        // Instantiate AppConfig
+        Ok(AppConfig { args: config_args })
+    }
+
+    #[cfg(not(test))]
+    #[inline(always)]
+    fn parse_config() -> AppConfigArgs {
+        AppConfigArgs::parse()
+    }
+
+    #[cfg(test)]
+    #[inline(always)]
+    fn parse_config() -> AppConfigArgs {
+        AppConfigArgs::parse_from::<Vec<_>, String>(vec![])
+    }
+}
+
+/// Unit tests
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use std::env;
+    use trust0_common::testutils;
+
+    pub fn setup_env_vars(authn_scheme_str: &str) {
+        env::set_var("AUTHN_SCHEME", authn_scheme_str);
+    }
+
+    #[test]
+    fn appcfg_new_when_scramsha256_authn_supplied() {
+        let result;
+        {
+            let mutex = testutils::TEST_MUTEX.clone();
+            let _lock = mutex.lock().unwrap();
+            setup_env_vars("scram-sha256");
+            result = AppConfig::new();
+        }
+
+        if let Err(err) = result {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+        let config = result.unwrap();
+
+        assert_eq!(config.args.authn_scheme, AuthnType::ScramSha256);
+    }
+}

--- a/crates/common/src/bin/trust0-password-hasher/console.rs
+++ b/crates/common/src/bin/trust0-password-hasher/console.rs
@@ -1,0 +1,176 @@
+use std::io::{self, stdin, stdout, BufRead, Write};
+
+use trust0_common::error::AppError;
+
+const APP_TITLE: &str = "Trust0 SDP Password Hasher";
+const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg(windows)]
+pub const LINE_ENDING: &'static str = "\r\n";
+#[cfg(not(windows))]
+pub const LINE_ENDING: &str = "\n";
+
+/// Handles console input, output
+pub struct Console {
+    reader: Box<dyn BufRead>,
+    writer: Box<dyn Write>,
+}
+
+impl Console {
+    /// Console constructor
+    /// If reader or writer object is not given, will use STDIN and STDOUT respectively
+    pub fn new(reader: Option<Box<dyn BufRead>>, writer: Option<Box<dyn Write>>) -> Self {
+        Self {
+            reader: reader.unwrap_or(Box::new(stdin().lock())),
+            writer: writer.unwrap_or(Box::new(stdout())),
+        }
+    }
+}
+
+impl ConsoleIO for Console {
+    fn write_title(&mut self) -> Result<(), AppError> {
+        self.write_data(
+            format!("{} v{}{}", APP_TITLE, APP_VERSION, LINE_ENDING).as_bytes(),
+            true,
+        )
+    }
+
+    fn write_data(&mut self, data: &[u8], flush_output: bool) -> Result<(), AppError> {
+        self.write_all(data).map_err(|err| {
+            AppError::GenWithMsgAndErr("Error writing data".to_string(), Box::new(err))
+        })?;
+        if flush_output {
+            self.flush().map_err(|err| {
+                AppError::GenWithMsgAndErr("Error flushing data".to_string(), Box::new(err))
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    fn read_next_line(&mut self, is_password_input: bool) -> Result<String, AppError> {
+        match is_password_input {
+            true => match rpassword::read_password() {
+                Ok(line) => Ok(line),
+                Err(err) => Err(AppError::GenWithMsgAndErr(
+                    "Error reading console (pwd) line".to_string(),
+                    Box::new(err),
+                )),
+            },
+            false => {
+                let mut line: String = String::new();
+                match self.reader.read_line(&mut line) {
+                    Ok(_) => Ok(line.trim_end().to_string()),
+                    Err(err) => Err(AppError::GenWithMsgAndErr(
+                        "Error reading console line".to_string(),
+                        Box::new(err),
+                    )),
+                }
+            }
+        }
+    }
+}
+
+pub trait ConsoleIO {
+    /// Display application title
+    fn write_title(&mut self) -> Result<(), AppError>;
+
+    /// Write content
+    fn write_data(&mut self, data: &[u8], flush_output: bool) -> Result<(), AppError>;
+
+    /// Blocking read for next input line, which will be sent to channel for processing
+    fn read_next_line(&mut self, is_password_input: bool) -> Result<String, AppError>;
+}
+
+impl Write for Console {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.writer.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.writer.flush()
+    }
+}
+
+/// Unit tests
+#[cfg(test)]
+pub mod tests {
+
+    use super::*;
+    use std::io::Cursor;
+    use std::sync::mpsc;
+    use std::sync::mpsc::TryRecvError;
+    use trust0_common::testutils::ChannelWriter;
+
+    #[test]
+    fn console_new() {
+        let output_channel = mpsc::channel();
+        let reader: Box<dyn BufRead> = Box::new(Cursor::new(vec![]));
+        let writer: Box<dyn Write> = Box::new(ChannelWriter {
+            channel_sender: output_channel.0,
+        });
+
+        let _ = Console::new(None, None);
+        let _ = Console::new(Some(reader), Some(writer));
+    }
+
+    #[test]
+    fn console_write_title() {
+        let output_channel = mpsc::channel();
+        let reader: Box<dyn BufRead> = Box::new(Cursor::new(vec![]));
+        let writer: Box<dyn Write> = Box::new(ChannelWriter {
+            channel_sender: output_channel.0,
+        });
+        let mut console = Console { reader, writer };
+
+        if let Err(err) = console.write_title() {
+            panic!("Unexpected function result: err={:?}", &err);
+        }
+
+        let mut output_data: Vec<u8> = vec![];
+
+        loop {
+            let output_result = output_channel.1.try_recv();
+            if let Err(err) = output_result {
+                if let TryRecvError::Empty = err {
+                    break;
+                }
+                panic!("Unexpected output result: err={:?}", &err);
+            }
+            output_data.append(&mut output_result.unwrap());
+        }
+
+        let expected_output = format!("{} v{}{}", APP_TITLE, APP_VERSION, LINE_ENDING).into_bytes();
+
+        assert_eq!(output_data, expected_output);
+    }
+
+    #[test]
+    fn console_read_next_line_when_2_lines_and_non_pwd_input() {
+        let output_channel = mpsc::channel();
+        let reader: Box<dyn BufRead> = Box::new(Cursor::new("line1\nline2\n".as_bytes().to_vec()));
+        let writer: Box<dyn Write> = Box::new(ChannelWriter {
+            channel_sender: output_channel.0,
+        });
+        let mut console = Console { reader, writer };
+
+        let mut actual_lines = vec![];
+        loop {
+            match console.read_next_line(false) {
+                Ok(line) => {
+                    if line.is_empty() {
+                        break;
+                    }
+                    actual_lines.push(line)
+                }
+                Err(err) => panic!(
+                    "Unexpected line result: recvd={:?}, err={:?}",
+                    &actual_lines, &err
+                ),
+            }
+        }
+
+        assert_eq!(actual_lines.len(), 2);
+        assert_eq!(actual_lines, vec!["line1", "line2"]);
+    }
+}

--- a/crates/common/src/bin/trust0-password-hasher/main.rs
+++ b/crates/common/src/bin/trust0-password-hasher/main.rs
@@ -1,0 +1,136 @@
+mod config;
+mod console;
+
+use std::process;
+
+use anyhow::Result;
+use trust0_common::authn::scram_sha256_authenticator;
+
+use crate::config::{AppConfig, AuthnType};
+use crate::console::{Console, ConsoleIO, LINE_ENDING};
+
+const LABEL_USERNAME: &[u8] = "Username: ".as_bytes();
+const LABEL_PASSWORD: &[u8] = "Password: ".as_bytes();
+
+fn process_runner(app_config: &AppConfig, console: &mut dyn ConsoleIO) -> Result<()> {
+    console.write_title()?;
+
+    match app_config.args.authn_scheme {
+        AuthnType::ScramSha256 => {
+            // Gather username, password
+            console.write_data(LABEL_USERNAME, true)?;
+            let username = console.read_next_line(false)?;
+            console.write_data(LABEL_PASSWORD, true)?;
+            let password = console.read_next_line(true)?;
+
+            // Generate password hash
+            console.write_data(
+                format!(
+                    "{}{}",
+                    String::from_utf8(scram_sha256_authenticator::hash_password(
+                        &username, &password, true
+                    ))?,
+                    LINE_ENDING
+                )
+                .as_bytes(),
+                true,
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+pub fn main() {
+    let app_config = AppConfig::new().unwrap();
+    let mut console = Console::new(None, None);
+    match process_runner(&app_config, &mut console) {
+        Ok(()) => {
+            process::exit(0);
+        }
+        Err(err) => {
+            eprintln!("{:?}", err);
+            process::exit(1);
+        }
+    }
+}
+
+// Unit tests
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::config::tests::setup_env_vars;
+    use trust0_common::error::AppError;
+    use trust0_common::testutils;
+
+    // structs
+    // =======
+    struct TestConsole {
+        in_data: Vec<String>,
+        out_title: Vec<String>,
+        out_data: Vec<String>,
+    }
+
+    impl ConsoleIO for TestConsole {
+        fn write_title(&mut self) -> Result<(), AppError> {
+            self.out_title.push("T".to_string());
+            Ok(())
+        }
+
+        fn write_data(&mut self, data: &[u8], flush_output: bool) -> Result<(), AppError> {
+            if flush_output {
+                let mut data = String::from_utf8(data.to_vec()).unwrap();
+                data.push('!');
+                self.out_data.push(data);
+            } else {
+                self.out_data
+                    .push(String::from_utf8(data.to_vec()).unwrap());
+            }
+            Ok(())
+        }
+
+        fn read_next_line(&mut self, _is_password_input: bool) -> Result<String, AppError> {
+            Ok(self.in_data.pop().unwrap())
+        }
+    }
+
+    // tests
+    // =====
+
+    #[test]
+    fn main_process_runner_when_scramsha256_authn() {
+        let mut console = TestConsole {
+            in_data: vec!["pass1".to_string(), "user1".to_string()],
+            out_title: vec![],
+            out_data: vec![],
+        };
+        let result;
+        {
+            let mutex = testutils::TEST_MUTEX.clone();
+            let _lock = mutex.lock().unwrap();
+            setup_env_vars("scram-sha256");
+            result = AppConfig::new();
+        }
+        if let Err(err) = result {
+            panic!("Unexpected app config creation result: err={:?}", &err);
+        }
+        let config = result.unwrap();
+
+        if let Err(err) = process_runner(&config, &mut console) {
+            panic!("Unexpected process runner result: err={:?}", &err);
+        }
+
+        let mut expected_username = String::from_utf8(LABEL_USERNAME.to_vec()).unwrap();
+        let mut expected_password = String::from_utf8(LABEL_PASSWORD.to_vec()).unwrap();
+        expected_username.push('!');
+        expected_password.push('!');
+        let expected_hash = "30nasGxfW9JzThsjsGSutayNhTgRNVxkv_Qm6ZUlW2U=\n!".to_string();
+
+        assert!(console.in_data.is_empty());
+        assert_eq!(console.out_title, vec!["T"]);
+        assert_eq!(
+            console.out_data,
+            vec![expected_username, expected_password, expected_hash]
+        );
+    }
+}

--- a/crates/common/src/crypto/alpn.rs
+++ b/crates/common/src/crypto/alpn.rs
@@ -7,7 +7,7 @@ pub const PROTOCOL_SERVICE: &str = "T0SRV";
 pub const PROTOCOL_SERVICE_PARSE_REGEX: &str = r"^T0SRV(\d+)$";
 
 /// Trust0 utilized ALPN protocol negotiation to determine connection type: Control Plane; Service Proxy
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Protocol {
     ControlPlane,
     Service(u64),

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,3 +1,4 @@
+mod authn;
 pub mod config;
 pub mod control;
 pub mod crypto;

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,4 +1,4 @@
-mod authn;
+pub mod authn;
 pub mod config;
 pub mod control;
 pub mod crypto;

--- a/crates/common/src/model/access.rs
+++ b/crates/common/src/model/access.rs
@@ -1,7 +1,7 @@
 use serde_derive::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default, Hash, Eq, PartialEq)]
-#[serde(rename_all(serialize = "snake_case", deserialize = "camelCase"))]
+#[serde(rename_all = "camelCase")]
 pub enum EntityType {
     #[default]
     None,
@@ -10,7 +10,7 @@ pub enum EntityType {
 }
 
 #[derive(Serialize, Deserialize, Clone, Default, PartialEq, Debug)]
-#[serde(rename_all(serialize = "snake_case", deserialize = "camelCase"))]
+#[serde(rename_all = "camelCase")]
 pub struct ServiceAccess {
     pub service_id: u64,
     pub entity_type: EntityType,

--- a/crates/common/src/model/role.rs
+++ b/crates/common/src/model/role.rs
@@ -1,7 +1,7 @@
 use serde_derive::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Default, PartialEq, Debug)]
-#[serde(rename_all(serialize = "snake_case", deserialize = "camelCase"))]
+#[serde(rename_all = "camelCase")]
 pub struct Role {
     pub role_id: u64,
     pub name: String,

--- a/crates/common/src/model/service.rs
+++ b/crates/common/src/model/service.rs
@@ -8,7 +8,7 @@ pub enum Transport {
 }
 
 #[derive(Serialize, Deserialize, Clone, Default, PartialEq, Debug)]
-#[serde(rename_all(serialize = "snake_case", deserialize = "camelCase"))]
+#[serde(rename_all = "camelCase")]
 pub struct Service {
     pub service_id: u64,
     pub name: String,

--- a/crates/common/src/model/user.rs
+++ b/crates/common/src/model/user.rs
@@ -1,16 +1,18 @@
 use serde_derive::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Default, PartialEq, Debug)]
-#[serde(rename_all(serialize = "snake_case", deserialize = "camelCase"))]
+#[serde(rename_all = "camelCase")]
 pub struct User {
     pub user_id: u64,
     pub name: String,
     pub status: Status,
     pub roles: Vec<u64>,
+    pub user_name: Option<String>,
+    pub password: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
-#[serde(rename_all(serialize = "snake_case", deserialize = "camelCase"))]
+#[serde(rename_all = "camelCase")]
 pub enum Status {
     #[default]
     Active,
@@ -19,9 +21,18 @@ pub enum Status {
 
 impl User {
     /// User constructor
-    pub fn new(user_id: u64, name: &str, status: Status, roles: &[u64]) -> Self {
+    pub fn new(
+        user_id: u64,
+        user_name: Option<&str>,
+        password: Option<&str>,
+        name: &str,
+        status: Status,
+        roles: &[u64],
+    ) -> Self {
         Self {
             user_id,
+            user_name: user_name.map(|u| u.to_string()),
+            password: password.map(|p| p.to_string()),
             name: name.to_string(),
             status,
             roles: roles.to_owned(),
@@ -37,8 +48,19 @@ pub mod tests {
     #[test]
     fn user_new() {
         let roles = vec![60, 61];
-        let user = User::new(100, "user100", Status::Active, &roles);
+        let user = User::new(
+            100,
+            Some("uname100"),
+            Some("pass100"),
+            "user100",
+            Status::Active,
+            &roles,
+        );
         assert_eq!(user.user_id, 100);
+        assert!(user.user_name.is_some());
+        assert_eq!(user.user_name.unwrap(), "uname100");
+        assert!(user.password.is_some());
+        assert_eq!(user.password.unwrap(), "pass100");
         assert_eq!(user.name, "user100");
         assert_eq!(user.status, Status::Active);
         assert_eq!(user.roles, roles);

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -24,6 +24,7 @@ pki-types = { package = "rustls-pki-types", version = "1.0.1" }
 rcgen = { version = "0.11.3", features = ["pem"], default-features = false }
 ring = "0.17.7"
 rustls = { version = "0.22.1", features = [ "logging" ] }
+scram = "0.6.0"
 sct = "0.7"
 serde = { version = "*", features = ["derive"] }
 serde_derive = "*"

--- a/crates/gateway/src/client/connection.rs
+++ b/crates/gateway/src/client/connection.rs
@@ -354,6 +354,8 @@ mod tests {
             .return_once(move |_| {
                 Ok(Some(User {
                     user_id: 100,
+                    user_name: Some("user1".to_string()),
+                    password: Some("pass1".to_string()),
                     name: "".to_string(),
                     status: Status::Active,
                     roles: vec![],
@@ -403,6 +405,8 @@ mod tests {
 
         let user = User {
             user_id: 100,
+            user_name: Some("user1".to_string()),
+            password: Some("pass1".to_string()),
             name: "".to_string(),
             status: Status::Active,
             roles: vec![],
@@ -471,6 +475,8 @@ mod tests {
 
         let user = User {
             user_id: 100,
+            user_name: Some("user1".to_string()),
+            password: Some("pass1".to_string()),
             name: "".to_string(),
             status: Status::Active,
             roles: vec![],
@@ -530,6 +536,8 @@ mod tests {
 
         let user = User {
             user_id: 100,
+            user_name: Some("user1".to_string()),
+            password: Some("pass1".to_string()),
             name: "".to_string(),
             status: Status::Active,
             roles: vec![],
@@ -662,6 +670,8 @@ mod tests {
 
         let user = User {
             user_id: 100,
+            user_name: Some("user1".to_string()),
+            password: Some("pass1".to_string()),
             name: "".to_string(),
             status: Status::Inactive,
             roles: vec![],

--- a/crates/gateway/src/client/connection.rs
+++ b/crates/gateway/src/client/connection.rs
@@ -25,9 +25,10 @@ pub struct ClientConnVisitor {
     service_repo: Arc<Mutex<dyn ServiceRepository>>,
     user_repo: Arc<Mutex<dyn UserRepository>>,
     event_channel_sender: Option<Sender<conn_std::ConnectionEvent>>,
-    request_processor: Option<Box<dyn RequestProcessor>>,
+    request_processor: Option<Arc<Mutex<dyn RequestProcessor>>>,
     device: Option<Device>,
     user: Option<User>,
+    protocol: Option<alpn::Protocol>,
     service_mgr: Arc<Mutex<dyn ServiceMgr>>,
 }
 
@@ -47,6 +48,7 @@ impl ClientConnVisitor {
             request_processor: None,
             device: None,
             user: None,
+            protocol: None,
             service_mgr,
         }
     }
@@ -57,7 +59,7 @@ impl ClientConnVisitor {
         tls_conn: &dyn TlsConnection,
         service_id: Option<u64>,
     ) -> Result<alpn::Protocol, AppError> {
-        // parse certificate context details
+        // Parse certificate context details
         let peer_certificates: Vec<CertificateDer<'static>> = tls_conn
             .peer_certificates()
             .ok_or(AppError::GenWithCodeAndMsg(
@@ -70,7 +72,7 @@ impl ClientConnVisitor {
 
         let device = Device::new(peer_certificates)?;
 
-        // validate user
+        // Validate user
         let user_id = device.get_cert_access_context().user_id;
 
         if user_id == 0 {
@@ -109,11 +111,46 @@ impl ClientConnVisitor {
             ));
         }
 
-        // determine (ALPN) connection protocol
+        // Determine (ALPN) connection protocol
         let alpn_protocol = Self::parse_alpn_protocol(&tls_conn.alpn_protocol())?;
 
-        // validate service (if necessary)
-        if service_id.is_some() {
+        // Validate control plane connection
+        if service_id.is_none() {
+            // Ensure no active control plane for user
+            if self
+                .service_mgr
+                .lock()
+                .unwrap()
+                .has_control_plane_for_user(user_id, false)
+            {
+                return Err(AppError::GenWithCodeAndMsg(
+                    config::RESPCODE_0426_CONTROL_PLANE_ALREADY_CONNECTED,
+                    format!(
+                        "Not allowed to have multiple control planes: uid={}",
+                        &user_id
+                    ),
+                ));
+            }
+        }
+        // Validate service connection
+        else {
+            // Ensure active control plane for user
+            if !self
+                .service_mgr
+                .lock()
+                .unwrap()
+                .has_control_plane_for_user(user_id, true)
+            {
+                return Err(AppError::GenWithCodeAndMsg(
+                    config::RESPCODE_0427_CONTROL_PLANE_NOT_AUTHENTICATED,
+                    format!(
+                        "Service proxy connections require an authenticated control plane: uid={}",
+                        &user_id
+                    ),
+                ));
+            }
+
+            // Validate requested service
             let service_id = service_id.unwrap();
 
             let invalid_service = match alpn_protocol {
@@ -131,6 +168,7 @@ impl ClientConnVisitor {
                 ));
             }
 
+            // Validate service accessibility for user
             if self
                 .access_repo
                 .lock()
@@ -150,6 +188,7 @@ impl ClientConnVisitor {
 
         self.device = Some(device);
         self.user = Some(user);
+        self.protocol = Some(alpn_protocol.clone());
 
         Ok(alpn_protocol)
     }
@@ -188,16 +227,29 @@ impl conn_std::ConnectionVisitor for ClientConnVisitor {
         &mut self,
         event_channel_sender: Sender<conn_std::ConnectionEvent>,
     ) -> Result<(), AppError> {
-        self.request_processor = Some(Box::new(ControlPlane::new(
-            self.app_config.clone(),
-            self.access_repo.clone(),
-            self.service_repo.clone(),
-            self.user_repo.clone(),
-            event_channel_sender.clone(),
-            self.device.as_ref().unwrap_or(&Device::default()).clone(),
-            self.user.as_ref().unwrap_or(&User::default()).clone(),
-        )?));
-
+        let user = self.user.as_ref().unwrap();
+        if self
+            .protocol
+            .as_ref()
+            .unwrap()
+            .eq(&alpn::Protocol::ControlPlane)
+        {
+            let request_processor: Arc<Mutex<dyn RequestProcessor>> =
+                Arc::new(Mutex::new(ControlPlane::new(
+                    self.app_config.clone(),
+                    self.access_repo.clone(),
+                    self.service_repo.clone(),
+                    self.user_repo.clone(),
+                    event_channel_sender.clone(),
+                    self.device.as_ref().unwrap().clone(),
+                    user.clone(),
+                )?));
+            self.service_mgr
+                .lock()
+                .unwrap()
+                .add_control_plane(user.user_id, request_processor.clone())?;
+            self.request_processor = Some(request_processor);
+        }
         self.event_channel_sender = Some(event_channel_sender);
 
         Ok(())
@@ -213,7 +265,9 @@ impl conn_std::ConnectionVisitor for ClientConnVisitor {
 
         let _ = self
             .request_processor
-            .as_mut()
+            .as_ref()
+            .unwrap()
+            .lock()
             .unwrap()
             .process_request(&self.service_mgr, &data_text)?;
 
@@ -260,7 +314,7 @@ impl conn_std::ConnectionVisitor for ClientConnVisitor {
         let event_sender = self.event_channel_sender.as_ref().unwrap();
 
         if let Err(err) = event_sender.send(conn_std::ConnectionEvent::Write(
-            format!("{}\n", msg).into_bytes(),
+            format!("{}{}", msg, config::LINE_ENDING).into_bytes(),
         )) {
             let _ = event_sender.send(conn_std::ConnectionEvent::Closing);
 
@@ -281,6 +335,8 @@ unsafe impl Send for ClientConnVisitor {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::client::controller::tests::MockReqProcessor;
+    use crate::client::device::CertAccessContext;
     use crate::repository::access_repo::tests::MockAccessRepo;
     use crate::repository::role_repo::tests::MockRoleRepo;
     use crate::repository::role_repo::RoleRepository;
@@ -289,10 +345,14 @@ mod tests {
     use crate::service::manager::GatewayServiceMgr;
     use crate::testutils::MockTlsSvrConn;
     use mockall::predicate;
+    use std::collections::HashMap;
+    use std::fmt;
     use std::path::PathBuf;
     use std::sync::mpsc;
+    use trust0_common::control::request;
     use trust0_common::crypto::file::load_certificates;
     use trust0_common::model::access::{EntityType, ServiceAccess};
+    use trust0_common::net::tls_server::conn_std::{ConnectionEvent, ConnectionVisitor};
     use trust0_common::proxy::event::ProxyEvent;
     use trust0_common::proxy::executor::ProxyExecutorEvent;
 
@@ -312,6 +372,7 @@ mod tests {
         service_repo: Arc<Mutex<dyn ServiceRepository>>,
         role_repo: Arc<Mutex<dyn RoleRepository>>,
         access_repo: Arc<Mutex<dyn AccessRepository>>,
+        user_control_plane: Option<(u64, Arc<Mutex<dyn RequestProcessor>>)>,
     ) -> Result<ClientConnVisitor, AppError> {
         let app_config = Arc::new(config::tests::create_app_config_with_repos(
             user_repo,
@@ -326,11 +387,27 @@ mod tests {
             proxy_tasks_sender,
             proxy_events_sender,
         )));
+        if user_control_plane.is_some() {
+            let user_control_plane = user_control_plane.unwrap();
+            service_mgr
+                .lock()
+                .unwrap()
+                .add_control_plane(user_control_plane.0, user_control_plane.1.clone())?;
+        }
         Ok(ClientConnVisitor::new(app_config, service_mgr))
     }
 
+    fn create_req_processor(is_authenticated: bool) -> Arc<Mutex<dyn RequestProcessor>> {
+        let mut req_processor = MockReqProcessor::new();
+        req_processor
+            .expect_is_authenticated()
+            .times(1)
+            .return_once(move || is_authenticated);
+        Arc::new(Mutex::new(req_processor))
+    }
+
     #[test]
-    fn cliconnvis_process_authorization_fn_when_nosvc_and_gooduser_and_goodproto(
+    fn cliconnvis_process_authorization_fn_when_nosvc_and_gooduser_and_goodproto_and_1stcontrol(
     ) -> Result<(), AppError> {
         let peer_certs_file: PathBuf = CERTFILE_CLIENT_UID100_PATHPARTS.iter().collect();
         let peer_certs = load_certificates(peer_certs_file.to_str().unwrap().to_string())?;
@@ -372,11 +449,24 @@ mod tests {
             Arc::new(Mutex::new(service_repo)),
             Arc::new(Mutex::new(role_repo)),
             Arc::new(Mutex::new(access_repo)),
+            None,
         )?;
+
+        assert!(cli_conn_visitor.device.is_none());
+        assert!(cli_conn_visitor.user.is_none());
+        assert!(cli_conn_visitor.protocol.is_none());
 
         let result = cli_conn_visitor.process_authorization(&tls_conn, None);
         if let Ok(protocol) = &result {
             if let alpn::Protocol::ControlPlane = protocol {
+                assert!(cli_conn_visitor.device.is_some());
+                assert!(cli_conn_visitor.user.is_some());
+                assert_eq!(cli_conn_visitor.user.as_ref().unwrap().user_id, 100);
+                assert!(cli_conn_visitor.protocol.is_some());
+                assert_eq!(
+                    cli_conn_visitor.protocol.as_ref().unwrap(),
+                    &alpn::Protocol::ControlPlane
+                );
                 return Ok(());
             }
         }
@@ -385,7 +475,72 @@ mod tests {
     }
 
     #[test]
-    fn cliconnvis_process_authorization_fn_when_goodsvc_and_gooduser_and_goodproto(
+    fn cliconnvis_process_authorization_fn_when_nosvc_and_gooduser_and_goodproto_and_2ndcontrol(
+    ) -> Result<(), AppError> {
+        let peer_certs_file: PathBuf = CERTFILE_CLIENT_UID100_PATHPARTS.iter().collect();
+        let peer_certs = load_certificates(peer_certs_file.to_str().unwrap().to_string())?;
+        let alpn_proto = alpn::PROTOCOL_CONTROL_PLANE.as_bytes().to_vec();
+
+        let mut tls_conn = MockTlsSvrConn::new();
+        tls_conn
+            .expect_peer_certificates()
+            .times(1)
+            .return_once(move || Some(peer_certs));
+        tls_conn
+            .expect_alpn_protocol()
+            .times(1)
+            .return_once(move || Some(alpn_proto));
+
+        let mut user_repo = MockUserRepo::new();
+        user_repo
+            .expect_get()
+            .with(predicate::eq(100))
+            .times(1)
+            .return_once(move |_| {
+                Ok(Some(User {
+                    user_id: 100,
+                    user_name: Some("user1".to_string()),
+                    password: Some("pass1".to_string()),
+                    name: "".to_string(),
+                    status: Status::Active,
+                    roles: vec![],
+                }))
+            });
+        let mut access_repo = MockAccessRepo::new();
+        access_repo.expect_get().never();
+        let mut service_repo = MockServiceRepo::new();
+        service_repo.expect_get().never();
+        let role_repo = MockRoleRepo::new();
+
+        let mut cli_conn_visitor = create_cliconnvis(
+            Arc::new(Mutex::new(user_repo)),
+            Arc::new(Mutex::new(service_repo)),
+            Arc::new(Mutex::new(role_repo)),
+            Arc::new(Mutex::new(access_repo)),
+            Some((100, Arc::new(Mutex::new(MockReqProcessor::new())))),
+        )?;
+
+        assert!(cli_conn_visitor.device.is_none());
+        assert!(cli_conn_visitor.user.is_none());
+        assert!(cli_conn_visitor.protocol.is_none());
+
+        let result = cli_conn_visitor.process_authorization(&tls_conn, None);
+        if let Err(err) = &result {
+            if let AppError::GenWithCodeAndMsg(code, _) = err {
+                if *code == config::RESPCODE_0426_CONTROL_PLANE_ALREADY_CONNECTED {
+                    assert!(cli_conn_visitor.device.is_none());
+                    assert!(cli_conn_visitor.user.is_none());
+                    assert!(cli_conn_visitor.protocol.is_none());
+                    return Ok(());
+                }
+            }
+        }
+
+        panic!("Unexpected result: val={:?}", &result);
+    }
+
+    #[test]
+    fn cliconnvis_process_authorization_fn_when_goodsvc_and_gooduser_and_goodproto_and_hascontrol(
     ) -> Result<(), AppError> {
         let peer_certs_file: PathBuf = CERTFILE_CLIENT_UID100_PATHPARTS.iter().collect();
         let peer_certs = load_certificates(peer_certs_file.to_str().unwrap().to_string())?;
@@ -440,12 +595,25 @@ mod tests {
             Arc::new(Mutex::new(service_repo)),
             Arc::new(Mutex::new(role_repo)),
             Arc::new(Mutex::new(access_repo)),
+            Some((100, create_req_processor(true))),
         )?;
+
+        assert!(cli_conn_visitor.device.is_none());
+        assert!(cli_conn_visitor.user.is_none());
+        assert!(cli_conn_visitor.protocol.is_none());
 
         let result = cli_conn_visitor.process_authorization(&tls_conn, Some(200));
         if let Ok(protocol) = &result {
             if let alpn::Protocol::Service(service_id) = protocol {
                 if *service_id == 200 {
+                    assert!(cli_conn_visitor.device.is_some());
+                    assert!(cli_conn_visitor.user.is_some());
+                    assert_eq!(cli_conn_visitor.user.as_ref().unwrap().user_id, 100);
+                    assert!(cli_conn_visitor.protocol.is_some());
+                    assert_eq!(
+                        cli_conn_visitor.protocol.as_ref().unwrap(),
+                        &alpn::Protocol::Service(200)
+                    );
                     return Ok(());
                 }
             }
@@ -455,7 +623,143 @@ mod tests {
     }
 
     #[test]
-    fn cliconnvis_process_authorization_fn_when_wrongsvc_and_gooduser_and_goodproto(
+    fn cliconnvis_process_authorization_fn_when_goodsvc_and_gooduser_and_goodproto_and_nocontrol(
+    ) -> Result<(), AppError> {
+        let peer_certs_file: PathBuf = CERTFILE_CLIENT_UID100_PATHPARTS.iter().collect();
+        let peer_certs = load_certificates(peer_certs_file.to_str().unwrap().to_string())?;
+        let alpn_proto = alpn::Protocol::create_service_protocol(200)
+            .as_bytes()
+            .to_vec();
+
+        let mut tls_conn = MockTlsSvrConn::new();
+        tls_conn
+            .expect_peer_certificates()
+            .times(1)
+            .return_once(move || Some(peer_certs));
+        tls_conn
+            .expect_alpn_protocol()
+            .times(1)
+            .return_once(move || Some(alpn_proto));
+
+        let user = User {
+            user_id: 100,
+            user_name: Some("user1".to_string()),
+            password: Some("pass1".to_string()),
+            name: "".to_string(),
+            status: Status::Active,
+            roles: vec![],
+        };
+
+        let mut user_repo = MockUserRepo::new();
+        let user_copy = user.clone();
+        user_repo
+            .expect_get()
+            .with(predicate::eq(100))
+            .times(1)
+            .return_once(move |_| Ok(Some(user_copy)));
+        let mut access_repo = MockAccessRepo::new();
+        access_repo.expect_get_for_user().never();
+        let mut service_repo = MockServiceRepo::new();
+        service_repo.expect_get().never();
+        let role_repo = MockRoleRepo::new();
+
+        let mut cli_conn_visitor = create_cliconnvis(
+            Arc::new(Mutex::new(user_repo)),
+            Arc::new(Mutex::new(service_repo)),
+            Arc::new(Mutex::new(role_repo)),
+            Arc::new(Mutex::new(access_repo)),
+            None,
+        )?;
+
+        assert!(cli_conn_visitor.device.is_none());
+        assert!(cli_conn_visitor.user.is_none());
+        assert!(cli_conn_visitor.protocol.is_none());
+
+        let result = cli_conn_visitor.process_authorization(&tls_conn, Some(201));
+        if let Err(err) = &result {
+            if let AppError::GenWithCodeAndMsg(code, _) = err {
+                if *code == config::RESPCODE_0427_CONTROL_PLANE_NOT_AUTHENTICATED {
+                    assert!(cli_conn_visitor.device.is_none());
+                    assert!(cli_conn_visitor.user.is_none());
+                    assert!(cli_conn_visitor.protocol.is_none());
+                    return Ok(());
+                }
+            }
+        }
+
+        panic!("Unexpected result: val={:?}", &result);
+    }
+
+    #[test]
+    fn cliconnvis_process_authorization_fn_when_goodsvc_and_gooduser_and_goodproto_and_nonauthed_control(
+    ) -> Result<(), AppError> {
+        let peer_certs_file: PathBuf = CERTFILE_CLIENT_UID100_PATHPARTS.iter().collect();
+        let peer_certs = load_certificates(peer_certs_file.to_str().unwrap().to_string())?;
+        let alpn_proto = alpn::Protocol::create_service_protocol(200)
+            .as_bytes()
+            .to_vec();
+
+        let mut tls_conn = MockTlsSvrConn::new();
+        tls_conn
+            .expect_peer_certificates()
+            .times(1)
+            .return_once(move || Some(peer_certs));
+        tls_conn
+            .expect_alpn_protocol()
+            .times(1)
+            .return_once(move || Some(alpn_proto));
+
+        let user = User {
+            user_id: 100,
+            user_name: Some("user1".to_string()),
+            password: Some("pass1".to_string()),
+            name: "".to_string(),
+            status: Status::Active,
+            roles: vec![],
+        };
+
+        let mut user_repo = MockUserRepo::new();
+        let user_copy = user.clone();
+        user_repo
+            .expect_get()
+            .with(predicate::eq(100))
+            .times(1)
+            .return_once(move |_| Ok(Some(user_copy)));
+        let mut access_repo = MockAccessRepo::new();
+        access_repo.expect_get_for_user().never();
+        let mut service_repo = MockServiceRepo::new();
+        service_repo.expect_get().never();
+        let role_repo = MockRoleRepo::new();
+
+        let mut cli_conn_visitor = create_cliconnvis(
+            Arc::new(Mutex::new(user_repo)),
+            Arc::new(Mutex::new(service_repo)),
+            Arc::new(Mutex::new(role_repo)),
+            Arc::new(Mutex::new(access_repo)),
+            Some((100, create_req_processor(false))),
+        )?;
+
+        assert!(cli_conn_visitor.device.is_none());
+        assert!(cli_conn_visitor.user.is_none());
+        assert!(cli_conn_visitor.protocol.is_none());
+
+        let result = cli_conn_visitor.process_authorization(&tls_conn, Some(201));
+        if let Err(err) = &result {
+            if let AppError::GenWithCodeAndMsg(code, _) = err {
+                if *code == config::RESPCODE_0427_CONTROL_PLANE_NOT_AUTHENTICATED {
+                    assert!(cli_conn_visitor.device.is_none());
+                    assert!(cli_conn_visitor.user.is_none());
+                    assert!(cli_conn_visitor.protocol.is_none());
+                    return Ok(());
+                }
+            }
+        }
+
+        panic!("Unexpected result: val={:?}", &result);
+    }
+
+    #[test]
+    fn cliconnvis_process_authorization_fn_when_wrongsvc_and_gooduser_and_goodproto_and_hascontrol(
     ) -> Result<(), AppError> {
         let peer_certs_file: PathBuf = CERTFILE_CLIENT_UID100_PATHPARTS.iter().collect();
         let peer_certs = load_certificates(peer_certs_file.to_str().unwrap().to_string())?;
@@ -503,12 +807,20 @@ mod tests {
             Arc::new(Mutex::new(service_repo)),
             Arc::new(Mutex::new(role_repo)),
             Arc::new(Mutex::new(access_repo)),
+            Some((100, create_req_processor(true))),
         )?;
+
+        assert!(cli_conn_visitor.device.is_none());
+        assert!(cli_conn_visitor.user.is_none());
+        assert!(cli_conn_visitor.protocol.is_none());
 
         let result = cli_conn_visitor.process_authorization(&tls_conn, Some(201));
         if let Err(err) = &result {
             if let AppError::GenWithCodeAndMsg(code, _) = err {
                 if *code == config::RESPCODE_0424_INVALID_ALPN_PROTOCOL {
+                    assert!(cli_conn_visitor.device.is_none());
+                    assert!(cli_conn_visitor.user.is_none());
+                    assert!(cli_conn_visitor.protocol.is_none());
                     return Ok(());
                 }
             }
@@ -518,7 +830,7 @@ mod tests {
     }
 
     #[test]
-    fn cliconnvis_process_authorization_fn_when_goodsvc_and_gooduser_and_wrongproto(
+    fn cliconnvis_process_authorization_fn_when_goodsvc_and_gooduser_and_wrongproto_and_hascontrol(
     ) -> Result<(), AppError> {
         let peer_certs_file: PathBuf = CERTFILE_CLIENT_UID100_PATHPARTS.iter().collect();
         let peer_certs = load_certificates(peer_certs_file.to_str().unwrap().to_string())?;
@@ -560,12 +872,20 @@ mod tests {
             Arc::new(Mutex::new(service_repo)),
             Arc::new(Mutex::new(role_repo)),
             Arc::new(Mutex::new(access_repo)),
+            Some((100, create_req_processor(true))),
         )?;
+
+        assert!(cli_conn_visitor.device.is_none());
+        assert!(cli_conn_visitor.user.is_none());
+        assert!(cli_conn_visitor.protocol.is_none());
 
         let result = cli_conn_visitor.process_authorization(&tls_conn, Some(200));
         if let Err(err) = &result {
             if let AppError::GenWithCodeAndMsg(code, _) = err {
                 if *code == config::RESPCODE_0424_INVALID_ALPN_PROTOCOL {
+                    assert!(cli_conn_visitor.device.is_none());
+                    assert!(cli_conn_visitor.user.is_none());
+                    assert!(cli_conn_visitor.protocol.is_none());
                     return Ok(());
                 }
             }
@@ -575,7 +895,8 @@ mod tests {
     }
 
     #[test]
-    fn cliconnvis_process_authorization_fn_when_nosvc_and_badcert() -> Result<(), AppError> {
+    fn cliconnvis_process_authorization_fn_when_nosvc_and_badcert_and_nocontrol(
+    ) -> Result<(), AppError> {
         let peer_certs_file: PathBuf = CERTFILE_NON_CLIENT_PATHPARTS.iter().collect();
         let peer_certs = load_certificates(peer_certs_file.to_str().unwrap().to_string())?;
 
@@ -599,12 +920,20 @@ mod tests {
             Arc::new(Mutex::new(service_repo)),
             Arc::new(Mutex::new(role_repo)),
             Arc::new(Mutex::new(access_repo)),
+            None,
         )?;
+
+        assert!(cli_conn_visitor.device.is_none());
+        assert!(cli_conn_visitor.user.is_none());
+        assert!(cli_conn_visitor.protocol.is_none());
 
         let result = cli_conn_visitor.process_authorization(&tls_conn, Some(200));
         if let Err(err) = &result {
             if let AppError::GenWithCodeAndMsg(code, _) = err {
                 if *code == config::RESPCODE_0420_INVALID_CLIENT_CERTIFICATE {
+                    assert!(cli_conn_visitor.device.is_none());
+                    assert!(cli_conn_visitor.user.is_none());
+                    assert!(cli_conn_visitor.protocol.is_none());
                     return Ok(());
                 }
             }
@@ -614,7 +943,8 @@ mod tests {
     }
 
     #[test]
-    fn cliconnvis_process_authorization_fn_when_nosvc_and_baduid() -> Result<(), AppError> {
+    fn cliconnvis_process_authorization_fn_when_nosvc_and_baduid_and_nocontrol(
+    ) -> Result<(), AppError> {
         let peer_certs_file: PathBuf = CERTFILE_CLIENT_UID100_PATHPARTS.iter().collect();
         let peer_certs = load_certificates(peer_certs_file.to_str().unwrap().to_string())?;
 
@@ -642,12 +972,20 @@ mod tests {
             Arc::new(Mutex::new(service_repo)),
             Arc::new(Mutex::new(role_repo)),
             Arc::new(Mutex::new(access_repo)),
+            None,
         )?;
+
+        assert!(cli_conn_visitor.device.is_none());
+        assert!(cli_conn_visitor.user.is_none());
+        assert!(cli_conn_visitor.protocol.is_none());
 
         let result = cli_conn_visitor.process_authorization(&tls_conn, None);
         if let Err(err) = &result {
             if let AppError::GenWithCodeAndMsg(code, _) = err {
                 if *code == config::RESPCODE_0421_UNKNOWN_USER {
+                    assert!(cli_conn_visitor.device.is_none());
+                    assert!(cli_conn_visitor.user.is_none());
+                    assert!(cli_conn_visitor.protocol.is_none());
                     return Ok(());
                 }
             }
@@ -657,7 +995,8 @@ mod tests {
     }
 
     #[test]
-    fn cliconnvis_process_authorization_fn_when_nosvc_and_inactiveuser() -> Result<(), AppError> {
+    fn cliconnvis_process_authorization_fn_when_nosvc_and_inactiveuser_and_nocontrol(
+    ) -> Result<(), AppError> {
         let peer_certs_file: PathBuf = CERTFILE_CLIENT_UID100_PATHPARTS.iter().collect();
         let peer_certs = load_certificates(peer_certs_file.to_str().unwrap().to_string())?;
 
@@ -694,12 +1033,20 @@ mod tests {
             Arc::new(Mutex::new(service_repo)),
             Arc::new(Mutex::new(role_repo)),
             Arc::new(Mutex::new(access_repo)),
+            None,
         )?;
+
+        assert!(cli_conn_visitor.device.is_none());
+        assert!(cli_conn_visitor.user.is_none());
+        assert!(cli_conn_visitor.protocol.is_none());
 
         let result = cli_conn_visitor.process_authorization(&tls_conn, None);
         if let Err(err) = &result {
             if let AppError::GenWithCodeAndMsg(code, _) = err {
                 if *code == config::RESPCODE_0422_INACTIVE_USER {
+                    assert!(cli_conn_visitor.device.is_none());
+                    assert!(cli_conn_visitor.user.is_none());
+                    assert!(cli_conn_visitor.protocol.is_none());
                     return Ok(());
                 }
             }
@@ -755,5 +1102,402 @@ mod tests {
                 .to_vec()
         ))
         .is_err());
+    }
+
+    #[test]
+    fn cliconnvis_set_event_channel_sender_when_control_plane() -> Result<(), AppError> {
+        let user_repo = MockUserRepo::new();
+        let access_repo = MockAccessRepo::new();
+        let mut service_repo = MockServiceRepo::new();
+        service_repo
+            .expect_get_all()
+            .times(1)
+            .return_once(|| Ok(vec![]));
+        let role_repo = MockRoleRepo::new();
+        let user = User {
+            user_id: 100,
+            user_name: Some("user1".to_string()),
+            password: Some("pass1".to_string()),
+            name: "".to_string(),
+            status: Status::Inactive,
+            roles: vec![],
+        };
+        let device = Device {
+            cert_access_context: CertAccessContext {
+                user_id: 100,
+                platform: "Linux".to_string(),
+            },
+            cert_alt_subj: HashMap::new(),
+            cert_subj: HashMap::new(),
+        };
+
+        let mut cli_conn_visitor = create_cliconnvis(
+            Arc::new(Mutex::new(user_repo)),
+            Arc::new(Mutex::new(service_repo)),
+            Arc::new(Mutex::new(role_repo)),
+            Arc::new(Mutex::new(access_repo)),
+            None,
+        )?;
+        cli_conn_visitor.user = Some(user.clone());
+        cli_conn_visitor.device = Some(device);
+        cli_conn_visitor.protocol = Some(alpn::Protocol::ControlPlane);
+
+        assert!(cli_conn_visitor.event_channel_sender.is_none());
+        assert!(cli_conn_visitor.request_processor.is_none());
+        assert!(!cli_conn_visitor
+            .service_mgr
+            .lock()
+            .unwrap()
+            .has_control_plane_for_user(100, false));
+
+        if let Err(err) = cli_conn_visitor.set_event_channel_sender(mpsc::channel().0) {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+
+        assert!(cli_conn_visitor.event_channel_sender.is_some());
+        assert!(cli_conn_visitor.request_processor.is_some());
+        assert!(cli_conn_visitor
+            .service_mgr
+            .lock()
+            .unwrap()
+            .has_control_plane_for_user(100, false));
+
+        Ok(())
+    }
+
+    #[test]
+    fn cliconnvis_set_event_channel_sender_when_service() -> Result<(), AppError> {
+        let user_repo = MockUserRepo::new();
+        let access_repo = MockAccessRepo::new();
+        let mut service_repo = MockServiceRepo::new();
+        service_repo.expect_get_all().never();
+        let role_repo = MockRoleRepo::new();
+        let user = User {
+            user_id: 100,
+            user_name: Some("user1".to_string()),
+            password: Some("pass1".to_string()),
+            name: "".to_string(),
+            status: Status::Inactive,
+            roles: vec![],
+        };
+        let device = Device {
+            cert_access_context: CertAccessContext {
+                user_id: 100,
+                platform: "Linux".to_string(),
+            },
+            cert_alt_subj: HashMap::new(),
+            cert_subj: HashMap::new(),
+        };
+
+        let mut cli_conn_visitor = create_cliconnvis(
+            Arc::new(Mutex::new(user_repo)),
+            Arc::new(Mutex::new(service_repo)),
+            Arc::new(Mutex::new(role_repo)),
+            Arc::new(Mutex::new(access_repo)),
+            None,
+        )?;
+        cli_conn_visitor.user = Some(user.clone());
+        cli_conn_visitor.device = Some(device);
+        cli_conn_visitor.protocol = Some(alpn::Protocol::Service(200));
+
+        assert!(cli_conn_visitor.event_channel_sender.is_none());
+        assert!(cli_conn_visitor.request_processor.is_none());
+        assert!(!cli_conn_visitor
+            .service_mgr
+            .lock()
+            .unwrap()
+            .has_control_plane_for_user(100, false));
+
+        if let Err(err) = cli_conn_visitor.set_event_channel_sender(mpsc::channel().0) {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+
+        assert!(cli_conn_visitor.event_channel_sender.is_some());
+        assert!(cli_conn_visitor.request_processor.is_none());
+        assert!(!cli_conn_visitor
+            .service_mgr
+            .lock()
+            .unwrap()
+            .has_control_plane_for_user(100, false));
+
+        Ok(())
+    }
+
+    #[test]
+    fn cliconnvis_on_connection_read_when_valid_data() -> Result<(), AppError> {
+        let user_repo = MockUserRepo::new();
+        let access_repo = MockAccessRepo::new();
+        let service_repo = MockServiceRepo::new();
+        let role_repo = MockRoleRepo::new();
+
+        let mut cli_conn_visitor = create_cliconnvis(
+            Arc::new(Mutex::new(user_repo)),
+            Arc::new(Mutex::new(service_repo)),
+            Arc::new(Mutex::new(role_repo)),
+            Arc::new(Mutex::new(access_repo)),
+            None,
+        )?;
+        let data = "data1";
+        let mut request_procesor = MockReqProcessor::new();
+        request_procesor
+            .expect_process_request()
+            .with(predicate::always(), predicate::eq(data.to_string()))
+            .return_once(|_, _| Ok(request::Request::Ignore));
+        cli_conn_visitor.request_processor = Some(Arc::new(Mutex::new(request_procesor)));
+
+        if let Err(err) = cli_conn_visitor.on_connection_read(data.as_bytes()) {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn cliconnvis_on_connection_read_when_invalid_data() -> Result<(), AppError> {
+        let user_repo = MockUserRepo::new();
+        let access_repo = MockAccessRepo::new();
+        let service_repo = MockServiceRepo::new();
+        let role_repo = MockRoleRepo::new();
+
+        let mut cli_conn_visitor = create_cliconnvis(
+            Arc::new(Mutex::new(user_repo)),
+            Arc::new(Mutex::new(service_repo)),
+            Arc::new(Mutex::new(role_repo)),
+            Arc::new(Mutex::new(access_repo)),
+            None,
+        )?;
+        let data = [0xff];
+        let mut request_procesor = MockReqProcessor::new();
+        request_procesor.expect_process_request().never();
+
+        if let Ok(()) = cli_conn_visitor.on_connection_read(&data) {
+            panic!("Unexpected successful result");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn cliconnvis_on_shutdown() -> Result<(), AppError> {
+        let user_repo = MockUserRepo::new();
+        let access_repo = MockAccessRepo::new();
+        let service_repo = MockServiceRepo::new();
+        let role_repo = MockRoleRepo::new();
+
+        let mut cli_conn_visitor = create_cliconnvis(
+            Arc::new(Mutex::new(user_repo)),
+            Arc::new(Mutex::new(service_repo)),
+            Arc::new(Mutex::new(role_repo)),
+            Arc::new(Mutex::new(access_repo)),
+            Some((100, Arc::new(Mutex::new(MockReqProcessor::new())))),
+        )?;
+        cli_conn_visitor.user = Some(User {
+            user_id: 100,
+            user_name: Some("user1".to_string()),
+            password: Some("pass1".to_string()),
+            name: "".to_string(),
+            status: Status::Inactive,
+            roles: vec![],
+        });
+
+        assert!(cli_conn_visitor
+            .service_mgr
+            .lock()
+            .unwrap()
+            .has_control_plane_for_user(100, false));
+
+        if let Err(err) = cli_conn_visitor.on_shutdown() {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+
+        assert!(!cli_conn_visitor
+            .service_mgr
+            .lock()
+            .unwrap()
+            .has_control_plane_for_user(100, false));
+
+        Ok(())
+    }
+
+    #[test]
+    fn cliconnvis_send_error_response_when_genwithcode_error() -> Result<(), AppError> {
+        let user_repo = MockUserRepo::new();
+        let access_repo = MockAccessRepo::new();
+        let service_repo = MockServiceRepo::new();
+        let role_repo = MockRoleRepo::new();
+
+        let mut cli_conn_visitor = create_cliconnvis(
+            Arc::new(Mutex::new(user_repo)),
+            Arc::new(Mutex::new(service_repo)),
+            Arc::new(Mutex::new(role_repo)),
+            Arc::new(Mutex::new(access_repo)),
+            Some((100, Arc::new(Mutex::new(MockReqProcessor::new())))),
+        )?;
+        let event_channel = mpsc::channel();
+        cli_conn_visitor.event_channel_sender = Some(event_channel.0);
+
+        cli_conn_visitor.send_error_response(&AppError::GenWithCode(
+            config::RESPCODE_0423_INVALID_REQUEST,
+        ));
+
+        let msg_event = event_channel.1.try_recv();
+        if let Err(err) = &msg_event {
+            panic!("Unexpected channel recv result: err={:?}", err);
+        }
+        match msg_event.as_ref().unwrap() {
+            ConnectionEvent::Write(data) => assert_eq!(
+                String::from_utf8(data.clone()).unwrap(),
+                format!("[E0423] Invalid request{}", config::LINE_ENDING)
+            ),
+            _ => panic!("Unexpected connection event: event={:?}", &msg_event),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn cliconnvis_send_error_response_when_genwithcodeandmsganderr_error() -> Result<(), AppError> {
+        let user_repo = MockUserRepo::new();
+        let access_repo = MockAccessRepo::new();
+        let service_repo = MockServiceRepo::new();
+        let role_repo = MockRoleRepo::new();
+
+        let mut cli_conn_visitor = create_cliconnvis(
+            Arc::new(Mutex::new(user_repo)),
+            Arc::new(Mutex::new(service_repo)),
+            Arc::new(Mutex::new(role_repo)),
+            Arc::new(Mutex::new(access_repo)),
+            Some((100, Arc::new(Mutex::new(MockReqProcessor::new())))),
+        )?;
+        let event_channel = mpsc::channel();
+        cli_conn_visitor.event_channel_sender = Some(event_channel.0);
+
+        cli_conn_visitor.send_error_response(&AppError::GenWithCodeAndMsgAndErr(
+            config::RESPCODE_0423_INVALID_REQUEST,
+            "msg1".to_string(),
+            Box::new(fmt::Error::default()),
+        ));
+
+        let msg_event = event_channel.1.try_recv();
+        if let Err(err) = &msg_event {
+            panic!("Unexpected channel recv result: err={:?}", err);
+        }
+        match msg_event.as_ref().unwrap() {
+            ConnectionEvent::Write(data) => assert_eq!(
+                String::from_utf8(data.clone()).unwrap(),
+                format!("[E0423] Invalid request{}", config::LINE_ENDING)
+            ),
+            _ => panic!("Unexpected connection event: event={:?}", &msg_event),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn cliconnvis_send_error_response_when_genwithcodeanderr_error() -> Result<(), AppError> {
+        let user_repo = MockUserRepo::new();
+        let access_repo = MockAccessRepo::new();
+        let service_repo = MockServiceRepo::new();
+        let role_repo = MockRoleRepo::new();
+
+        let mut cli_conn_visitor = create_cliconnvis(
+            Arc::new(Mutex::new(user_repo)),
+            Arc::new(Mutex::new(service_repo)),
+            Arc::new(Mutex::new(role_repo)),
+            Arc::new(Mutex::new(access_repo)),
+            Some((100, Arc::new(Mutex::new(MockReqProcessor::new())))),
+        )?;
+        let event_channel = mpsc::channel();
+        cli_conn_visitor.event_channel_sender = Some(event_channel.0);
+
+        cli_conn_visitor.send_error_response(&AppError::GenWithCodeAndErr(
+            config::RESPCODE_0423_INVALID_REQUEST,
+            Box::new(fmt::Error::default()),
+        ));
+
+        let msg_event = event_channel.1.try_recv();
+        if let Err(err) = &msg_event {
+            panic!("Unexpected channel recv result: err={:?}", err);
+        }
+        match msg_event.as_ref().unwrap() {
+            ConnectionEvent::Write(data) => assert_eq!(
+                String::from_utf8(data.clone()).unwrap(),
+                format!("[E0423] Invalid request{}", config::LINE_ENDING)
+            ),
+            _ => panic!("Unexpected connection event: event={:?}", &msg_event),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn cliconnvis_send_error_response_when_genwithcodeandmsg_error() -> Result<(), AppError> {
+        let user_repo = MockUserRepo::new();
+        let access_repo = MockAccessRepo::new();
+        let service_repo = MockServiceRepo::new();
+        let role_repo = MockRoleRepo::new();
+
+        let mut cli_conn_visitor = create_cliconnvis(
+            Arc::new(Mutex::new(user_repo)),
+            Arc::new(Mutex::new(service_repo)),
+            Arc::new(Mutex::new(role_repo)),
+            Arc::new(Mutex::new(access_repo)),
+            Some((100, Arc::new(Mutex::new(MockReqProcessor::new())))),
+        )?;
+        let event_channel = mpsc::channel();
+        cli_conn_visitor.event_channel_sender = Some(event_channel.0);
+
+        cli_conn_visitor.send_error_response(&AppError::GenWithCodeAndMsg(
+            config::RESPCODE_0423_INVALID_REQUEST,
+            "msg1".to_string(),
+        ));
+
+        let msg_event = event_channel.1.try_recv();
+        if let Err(err) = &msg_event {
+            panic!("Unexpected channel recv result: err={:?}", err);
+        }
+        match msg_event.as_ref().unwrap() {
+            ConnectionEvent::Write(data) => assert_eq!(
+                String::from_utf8(data.clone()).unwrap(),
+                format!("[E0423] Invalid request{}", config::LINE_ENDING)
+            ),
+            _ => panic!("Unexpected connection event: event={:?}", &msg_event),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn cliconnvis_send_error_response_when_other_error() -> Result<(), AppError> {
+        let user_repo = MockUserRepo::new();
+        let access_repo = MockAccessRepo::new();
+        let service_repo = MockServiceRepo::new();
+        let role_repo = MockRoleRepo::new();
+
+        let mut cli_conn_visitor = create_cliconnvis(
+            Arc::new(Mutex::new(user_repo)),
+            Arc::new(Mutex::new(service_repo)),
+            Arc::new(Mutex::new(role_repo)),
+            Arc::new(Mutex::new(access_repo)),
+            Some((100, Arc::new(Mutex::new(MockReqProcessor::new())))),
+        )?;
+        let event_channel = mpsc::channel();
+        cli_conn_visitor.event_channel_sender = Some(event_channel.0);
+
+        cli_conn_visitor.send_error_response(&AppError::General("msg1".to_string()));
+
+        let msg_event = event_channel.1.try_recv();
+        if let Err(err) = &msg_event {
+            panic!("Unexpected channel recv result: err={:?}", err);
+        }
+        match msg_event.as_ref().unwrap() {
+            ConnectionEvent::Write(data) => assert_eq!(
+                String::from_utf8(data.clone()).unwrap(),
+                format!("[E0500] System error occurred{}", config::LINE_ENDING)
+            ),
+            _ => panic!("Unexpected connection event: event={:?}", &msg_event),
+        }
+
+        Ok(())
     }
 }

--- a/crates/gateway/src/client/controller.rs
+++ b/crates/gateway/src/client/controller.rs
@@ -523,6 +523,11 @@ impl server_std::ServerVisitor for ControlPlaneServerVisitor {
 
         let alpn_protocol = conn_visitor.process_authorization(&tls_conn, None)?;
 
+        // TODO
+        // .... authenticate_cert
+        // .... authenticate_mfa
+        // .... authorize_service
+
         let connection =
             conn_std::Connection::new(Box::new(conn_visitor), tls_conn, alpn_protocol)?;
 

--- a/crates/gateway/src/client/device.rs
+++ b/crates/gateway/src/client/device.rs
@@ -21,13 +21,13 @@ pub struct CertAccessContext {
 #[derive(Clone, Default, Debug)]
 pub struct Device {
     /// Certificate subject attributes
-    cert_subj: HashMap<String, Vec<String>>,
+    pub cert_subj: HashMap<String, Vec<String>>,
 
     /// Certificate alternate subject name attributes
-    cert_alt_subj: HashMap<String, Vec<String>>,
+    pub cert_alt_subj: HashMap<String, Vec<String>>,
 
     /// Device certificate info
-    cert_access_context: CertAccessContext,
+    pub cert_access_context: CertAccessContext,
 }
 
 impl Device {

--- a/crates/gateway/src/client/device.rs
+++ b/crates/gateway/src/client/device.rs
@@ -11,7 +11,7 @@ use trust0_common::crypto::asn;
 use trust0_common::error::AppError;
 
 #[derive(Serialize, Deserialize, Clone, Default, Debug)]
-#[serde(rename_all(serialize = "snake_case", deserialize = "camelCase"))]
+#[serde(rename_all = "camelCase")]
 pub struct CertAccessContext {
     pub user_id: u64,
     pub platform: String,

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -22,6 +22,7 @@ use regex::Regex;
 use rustls::crypto::CryptoProvider;
 use rustls::server::danger::ClientCertVerifier;
 use rustls::server::WebPkiClientVerifier;
+use trust0_common::authn::authenticator::AuthnType;
 use trust0_common::crypto::alpn;
 use trust0_common::crypto::file::CRLFile;
 use trust0_common::crypto::file::{load_certificates, load_private_key};
@@ -181,6 +182,10 @@ pub struct AppConfigArgs {
     #[arg(required = false, long = "gateway-service-reply-host", env)]
     pub gateway_service_reply_host: Option<String>,
 
+    /// Secondary authentication mechanism
+    #[arg(required = false, long = "mfa-scheme", default_value_t = trust0_common::authn::authenticator::AuthnType::Insecure, env)]
+    pub mfa_scheme: AuthnType,
+
     /// Enable verbose logging
     #[arg(required = false, long = "verbose", env)]
     pub verbose: bool,
@@ -287,6 +292,7 @@ pub struct AppConfig {
     pub server_port: u16,
     pub tls_server_config_builder: TlsServerConfigBuilder,
     pub crl_reloader_loading: Arc<Mutex<bool>>,
+    pub mfa_scheme: AuthnType,
     pub verbose_logging: bool,
     pub access_repo: Arc<Mutex<dyn AccessRepository>>,
     pub service_repo: Arc<Mutex<dyn ServiceRepository>>,
@@ -395,6 +401,7 @@ impl AppConfig {
             server_port: config_args.port,
             tls_server_config_builder,
             crl_reloader_loading,
+            mfa_scheme: config_args.mfa_scheme,
             verbose_logging: config_args.verbose,
             access_repo: repositories.0,
             service_repo: repositories.1,
@@ -601,6 +608,7 @@ pub mod tests {
             server_port: 2000,
             tls_server_config_builder,
             crl_reloader_loading: Arc::new(Mutex::new(false)),
+            mfa_scheme: AuthnType::Insecure,
             verbose_logging: false,
             access_repo,
             service_repo,

--- a/crates/gateway/src/repository/access_repo/in_memory_repo.rs
+++ b/crates/gateway/src/repository/access_repo/in_memory_repo.rs
@@ -559,8 +559,14 @@ mod tests {
             .unwrap()
             .insert(access_keys[2].clone(), accesses[2].clone());
 
-        let result =
-            access_repo.get_all_for_user(&User::new(10, "name10", Status::Active, &vec![]));
+        let result = access_repo.get_all_for_user(&User::new(
+            10,
+            Some("uname10"),
+            Some("pass10"),
+            "name10",
+            Status::Active,
+            &vec![],
+        ));
 
         if let Err(err) = &result {
             panic!("Unexpected result: err={:?}", &err)
@@ -611,7 +617,14 @@ mod tests {
             .unwrap()
             .insert(access_keys[2].clone(), accesses[2].clone());
 
-        let result = access_repo.get_all_for_user(&User::new(1, "name1", Status::Active, &vec![]));
+        let result = access_repo.get_all_for_user(&User::new(
+            1,
+            Some("uname1"),
+            Some("pass1"),
+            "name1",
+            Status::Active,
+            &vec![],
+        ));
 
         if let Err(err) = &result {
             panic!("Unexpected result: err={:?}", &err)
@@ -694,8 +707,14 @@ mod tests {
             .unwrap()
             .insert(access_keys[2].clone(), accesses[2].clone());
 
-        let result =
-            access_repo.get_all_for_user(&User::new(1, "name1", Status::Active, &vec![10]));
+        let result = access_repo.get_all_for_user(&User::new(
+            1,
+            Some("uname1"),
+            Some("pass1"),
+            "name1",
+            Status::Active,
+            &vec![10],
+        ));
 
         if let Err(err) = &result {
             panic!("Unexpected result: err={:?}", &err)
@@ -778,8 +797,17 @@ mod tests {
             .unwrap()
             .insert(access_keys[2].clone(), accesses[2].clone());
 
-        let result =
-            access_repo.get_for_user(4, &User::new(10, "name10", Status::Active, &vec![50]));
+        let result = access_repo.get_for_user(
+            4,
+            &User::new(
+                10,
+                Some("uname10"),
+                Some("pass10"),
+                "name10",
+                Status::Active,
+                &vec![50],
+            ),
+        );
 
         if let Err(err) = &result {
             panic!("Unexpected result: err={:?}", &err)
@@ -830,7 +858,17 @@ mod tests {
             .unwrap()
             .insert(access_keys[2].clone(), accesses[2].clone());
 
-        let result = access_repo.get_for_user(2, &User::new(1, "name1", Status::Active, &vec![50]));
+        let result = access_repo.get_for_user(
+            2,
+            &User::new(
+                1,
+                Some("uname1"),
+                Some("pass1"),
+                "name1",
+                Status::Active,
+                &vec![50],
+            ),
+        );
 
         if let Err(err) = &result {
             panic!("Unexpected result: err={:?}", &err)
@@ -890,7 +928,17 @@ mod tests {
             .unwrap()
             .insert(access_keys[2].clone(), accesses[2].clone());
 
-        let result = access_repo.get_for_user(5, &User::new(1, "name1", Status::Active, &vec![10]));
+        let result = access_repo.get_for_user(
+            5,
+            &User::new(
+                1,
+                Some("uname1"),
+                Some("pass1"),
+                "name1",
+                Status::Active,
+                &vec![10],
+            ),
+        );
 
         if let Err(err) = &result {
             panic!("Unexpected result: err={:?}", &err)

--- a/crates/gateway/src/repository/user_repo/in_memory_repo.rs
+++ b/crates/gateway/src/repository/user_repo/in_memory_repo.rs
@@ -200,6 +200,8 @@ mod tests {
                 100,
                 User {
                     user_id: 100,
+                    user_name: Some("uname100".to_string()),
+                    password: Some("pass100".to_string()),
                     name: "User100".to_string(),
                     status: Status::Active,
                     roles: vec![60, 61],
@@ -209,6 +211,8 @@ mod tests {
                 101,
                 User {
                     user_id: 101,
+                    user_name: Some("uname101".to_string()),
+                    password: Some("pass101".to_string()),
                     name: "User101".to_string(),
                     status: Status::Active,
                     roles: vec![],
@@ -255,7 +259,7 @@ mod tests {
         assert_eq!(user_repo.users.read().unwrap().len(), 2);
 
         *user_repo.reloader_new_data.lock().unwrap() =
-            "[{\"userId\": 800, \"name\": \"User800\", \"status\": \"inactive\", \"roles\": [600]}]".to_string();
+            "[{\"userId\": 800, \"userName\": \"user800\", \"password\": \"pass800\", \"name\": \"User800\", \"status\": \"inactive\", \"roles\": [600]}]".to_string();
 
         if let Err(err) = user_repo.process_source_data_updates() {
             panic!("Unexpected process updates result: err={:?}", &err);
@@ -265,6 +269,8 @@ mod tests {
             800,
             User {
                 user_id: 800,
+                user_name: Some("uname800".to_string()),
+                password: Some("pass800".to_string()),
                 name: "User800".to_string(),
                 status: Status::Inactive,
                 roles: vec![600],
@@ -310,7 +316,7 @@ mod tests {
         assert_eq!(user_repo.users.read().unwrap().len(), 2);
 
         *user_repo.reloader_new_data.lock().unwrap() =
-            "[{\"userId\": 800, \"name\": \"User800\", \"status\": \"inactive\", \"roles\": [600]}"
+            "[{\"userId\": 800, \"userName\": \"user800\", \"password\": \"pass800\", \"name\": \"User800\", \"status\": \"inactive\", \"roles\": [600]}"
                 .to_string();
 
         if let Ok(()) = user_repo.process_source_data_updates() {
@@ -331,6 +337,8 @@ mod tests {
         let user_key = 1;
         let user = User {
             user_id: 1,
+            user_name: Some("uname1".to_string()),
+            password: Some("pass1".to_string()),
             name: "user1".to_string(),
             status: Status::Active,
             roles: vec![60, 61],
@@ -353,6 +361,8 @@ mod tests {
         let user_key = 1;
         let user = User {
             user_id: 1,
+            user_name: Some("uname1".to_string()),
+            password: Some("pass1".to_string()),
             name: "user1".to_string(),
             status: Status::Active,
             roles: vec![60, 61],
@@ -376,18 +386,24 @@ mod tests {
         let users = [
             User {
                 user_id: 1,
+                user_name: Some("uname1".to_string()),
+                password: Some("pass1".to_string()),
                 name: "user1".to_string(),
                 status: Status::Active,
                 roles: vec![60],
             },
             User {
                 user_id: 2,
+                user_name: Some("uname2".to_string()),
+                password: Some("pass2".to_string()),
                 name: "user2".to_string(),
                 status: Status::Active,
                 roles: vec![],
             },
             User {
                 user_id: 3,
+                user_name: Some("uname3".to_string()),
+                password: Some("pass3".to_string()),
                 name: "user3".to_string(),
                 status: Status::Inactive,
                 roles: vec![61, 62],
@@ -429,18 +445,24 @@ mod tests {
         let users = [
             User {
                 user_id: 1,
+                user_name: Some("uname1".to_string()),
+                password: Some("pass1".to_string()),
                 name: "user1".to_string(),
                 status: Status::Active,
                 roles: vec![60],
             },
             User {
                 user_id: 2,
+                user_name: Some("uname2".to_string()),
+                password: Some("pass2".to_string()),
                 name: "user2".to_string(),
                 status: Status::Active,
                 roles: vec![],
             },
             User {
                 user_id: 3,
+                user_name: Some("uname3".to_string()),
+                password: Some("pass3".to_string()),
                 name: "user3".to_string(),
                 status: Status::Inactive,
                 roles: vec![61, 62],
@@ -477,6 +499,8 @@ mod tests {
                 1,
                 User {
                     user_id: 1,
+                    user_name: Some("uname1".to_string()),
+                    password: Some("pass1".to_string()),
                     name: "user1".to_string(),
                     status: Status::Active,
                     roles: vec![60],
@@ -486,6 +510,8 @@ mod tests {
                 2,
                 User {
                     user_id: 2,
+                    user_name: Some("uname2".to_string()),
+                    password: Some("pass2".to_string()),
                     name: "user2".to_string(),
                     status: Status::Active,
                     roles: vec![],
@@ -495,6 +521,8 @@ mod tests {
                 3,
                 User {
                     user_id: 3,
+                    user_name: Some("uname3".to_string()),
+                    password: Some("pass3".to_string()),
                     name: "user3".to_string(),
                     status: Status::Inactive,
                     roles: vec![61, 62],
@@ -517,6 +545,8 @@ mod tests {
         let user_key = 1;
         let user = User {
             user_id: 1,
+            user_name: Some("uname1".to_string()),
+            password: Some("pass1".to_string()),
             name: "user1".to_string(),
             status: Status::Active,
             roles: vec![],
@@ -539,6 +569,8 @@ mod tests {
         let user_key = 1;
         let user = User {
             user_id: 1,
+            user_name: Some("uname1".to_string()),
+            password: Some("pass1".to_string()),
             name: "user1".to_string(),
             status: Status::Active,
             roles: vec![60, 61],

--- a/crates/gateway/testdata/db-user.json
+++ b/crates/gateway/testdata/db-user.json
@@ -1,12 +1,16 @@
 [
     {
         "userId": 100,
+        "userName": "user1",
+        "password": "30nasGxfW9JzThsjsGSutayNhTgRNVxkv_Qm6ZUlW2U=",
         "name": "User100",
         "status":  "active",
         "roles": [ 50, 51 ]
     },
     {
         "userId": 101,
+        "userName": null,
+        "password": null,
         "name": "User101",
         "status":  "active",
         "roles":  [] }

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -4,11 +4,12 @@
   * [Trust0 Architecture](#trust0-architecture)
     * [Overview](#overview)
     * [Network Diagram](#network-diagram)
+    * [User Connections](#user-connections)
     * [Control Plane](#control-plane)
     * [Service Proxy](#service-proxy)
     * [Client Auth](#client-auth)
       * [mTLS Authentication](#mtls-authentication)
-      * [User Connections](#user-connections)
+      * [Secondary Authentication](#secondary-authentication)
       * [RBAC Authorization](#rbac-authorization)
       * [Certificate Revocation](#certificate-revocation)
     * [Database](#database)
@@ -30,13 +31,24 @@ Likewise, there are 2 types of T0C -> T0G connections:
 * Control Plane
 * Service Proxy
 
-Both connection types require mTLS, which allows both parties to authenticate each other. The T0C will use a certificate, which has embedded (device/)user information. This is used by the T0G to validate their account and determine their authorized services. The T0G has access to 3 DBs: users, services, and service authorization.
+Both connection types require mTLS, which allows both parties to authenticate each other (an optional secondary client authentication may also be enabled). The T0C will use a certificate, which has embedded (device/)user information. This is used by the T0G to validate their account and determine their authorized services. The T0G has access to 3 DBs: users, services, and service authorization.
 
 There is no authentication enforced for network connections made to the T0C. Likewise, this client is not secure to run on a multi-user machine and should be only be used on a single-user/personal computer (or some other scenario that can restrict access).
 
 ### Network Diagram
 
 ![](https://raw.githubusercontent.com/chewyfish/project-assets/main/trust0/network-diagram.png)
+
+### User Connections
+
+All user connections use the same gateway port. The gateway knows the kind of connection based on the TLS application-layer protocol negotiation (ALPN) value given by the Trust0 client. The types of values are as follows:
+
+| Pattern       | Description                                                              |
+|---------------|--------------------------------------------------------------------------|
+| T0CP          | Control Plane                                                            |
+| T0SRV<SVC_ID> | Service Proxy (for service denoted by service ID (u64 value) `<SVC_ID>`) |
+
+Note - A future Trust0 may accommodate gateway-to-gateway service proxy routing. In this case, gateway's will also use TLS client authentication in the same manner as clients (albeit they will have a different SAN field JSON structure to denote themselves as gateways).
 
 ### Control Plane
 
@@ -121,16 +133,11 @@ This allows the gateway to identify the user by their "userId" value (currently 
 
 Subsequently, it will check the respective [User Table](#user-table) record for the current status (values: `active`, `inactive`) and allow or prohibit the user connection accordingly.
 
-#### User Connections
+#### Secondary Authentication
 
-All user connections use the same gateway port. The gateway knows the kind of connection based on the TLS application-layer protocol negotiation (ALPN) value given by the Trust0 client. The types of values are as follows:
+In addition to TLS client authentication, Trust0 supports additional authentication scheme to be employed. Currently only a SCRAM SHA256 implementation is available. If enabled on the gateway, privileged control plane actions and service proxy connections will be guarded against access if the user hasn't passed this secondary authentication. This is accomplished via a `login` control plane flow.
 
-| Pattern       | Description                                                              |
-|---------------|--------------------------------------------------------------------------|
-| T0CP          | Control Plane                                                            |
-| T0SRV<SVC_ID> | Service Proxy (for service denoted by service ID (u64 value) `<SVC_ID>`) |
-
-Note - A future Trust0 may accommodate gateway-to-gateway service proxy routing. In this case, gateway's will also use TLS client authentication in the same manner as clients (albeit they will have a different SAN field JSON structure to denote themselves as gateways).
+The SCRAM SHA256 authentication will use the user credentials stored in the user's [User Table](#user-table) record. The hashed password value can be obtained using the included  [Trust0 Password Hasher](./Utilities.md#trust0-password-hasher) utility.
 
 #### RBAC Authorization
 
@@ -157,12 +164,14 @@ The repository is exposed as an abstract trait, so additional DB implementations
 
 User table contains records for each user account.
 
-| Field   | Description                                                |
-|---------|------------------------------------------------------------|
-| user ID | A unique integer serving as the primary key for the record |
-| name    | Personal name for user                                     |
-| status  | Account status field. Values are: 'inactive', 'active      |
-| roles   | List of RBAC role IDs assigned to this user                |
+| Field     | Description                                                     |
+|-----------|-----------------------------------------------------------------|
+| user ID   | A unique integer serving as the primary key for the record      |
+| user name | An user name used in a (optional) secondary authentication flow |
+| password  | An password used in a (optional) secondary authentication flow  |
+| name      | Personal name for user                                          |
+| status    | Account status field. Values are: 'inactive', 'active           |
+| roles     | List of RBAC role IDs assigned to this user                     |
 
 #### Role Table
 

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -54,17 +54,18 @@ Note - A future Trust0 may accommodate gateway-to-gateway service proxy routing.
 
 The Control Plane connection is required and the first connection made between the T0C and a T0G. A REPL shell will be opened and the user may enter various commands:
 
-| Command     | Description                                                         |
-|-------------|---------------------------------------------------------------------|
-| about       | Display context information for connected mTLS device user          |
-| connections | List current service proxy connections                              |
-| ping        | Simple gateway heartbeat request                                    |
-| proxies     | List active service proxies, ready for new connections              |
-| services    | List authorized services for connected mTLS device user             |
-| start       | Startup proxy to authorized service via secure client-gateway proxy |
-| stop        | Shutdown active service proxy (previously started)                  |
-| quit        | Quit the control plane (and corresponding service connections)      |
-| help        | Print this message or the help of the given subcommand(s)           |
+| Command     | Description                                                               |
+|-------------|---------------------------------------------------------------------------|
+| about       | Display context information for connected mTLS device user                |
+| connections | List current service proxy connections                                    |
+| login       | Perform challenge-response authentication (if gateway configured for MFA) |
+| ping        | Simple gateway heartbeat request                                          |
+| proxies     | List active service proxies, ready for new connections                    |
+| services    | List authorized services for connected mTLS device user                   |
+| start       | Startup proxy to authorized service via secure client-gateway proxy       |
+| stop        | Shutdown active service proxy (previously started)                        |
+| quit        | Quit the control plane (and corresponding service connections)            |
+| help        | Print this message or the help of the given subcommand(s)                 |
 
 In the REPL shell, issue `help <COMMAND>` to learn more about these commands.
 

--- a/docs/Invocation.md
+++ b/docs/Invocation.md
@@ -100,6 +100,14 @@ Options:
           
           [env: GATEWAY_SERVICE_REPLY_HOST=]
 
+      --mfa-scheme <MFA_SCHEME>
+          Secondary authentication mechanism (in addition to client certificate authentication)
+          Current schemes: 'insecure': No authentication, all privileged actions allowed
+                           'scram-sha256': SCRAM SHA256 using credentials stored in user repository
+          
+          [env: MFA_SCHEME=]
+          [default: insecure]
+
       --verbose
           Enable verbose logging
           
@@ -129,6 +137,11 @@ Options:
           Service entity store connect specifier string
           
           [env: SERVICE_DB_CONNECT=]
+
+      --role-db-connect <ROLE_DB_CONNECT>
+          Role entity store connect specifier string
+          
+          [env: ROLE_DB_CONNECT=]
 
       --user-db-connect <USER_DB_CONNECT>
           User entity store connect specifier string

--- a/docs/Utilities.md
+++ b/docs/Utilities.md
@@ -3,6 +3,7 @@
 <!-- TOC -->
   * [Trust0 Utilities](#trust0-utilities)
       * [Trust0 Client Installer](#trust0-client-installer)
+      * [Trust0 Password Hasher](#trust0-password-hasher)
       * [Create Root CA PKI Resources](#create-root-ca-pki-resources)
       * [Create Gateway PKI Resources](#create-gateway-pki-resources)
       * [Create Client PKI Resources](#create-client-pki-resources)
@@ -132,6 +133,43 @@ Installed client certificate: path="<USER_HOME>/.local/share/Trust0/pki/trust0-c
 Installed client key: path="<USER_HOME>/.local/share/Trust0/pki/trust0-client.key.pem"
 Installed client config: path="<USER_HOME>/.config/Trust0/trust0-client.conf"
 Installation complete! Consider adding '"<USER_HOME>/.local/share/Trust0/bin"' to the executable search path.
+```
+
+#### Trust0 Password Hasher
+
+The common crate has a user password hashing tool (`trust0-password-hasher`), which will correctly create a hashed password that can be stored in the [User Table](./Architecture.md#user-table). This can be used by an optional secondary gateway authentication procedure (if gateway is configured for a scheme that requires user password credentials).
+
+When invoking the tool, merely provide the correct authentication scheme, subsequently you will be prompted for a username and password, then the hashed password will be displayed.
+
+Here is the usage description:
+
+```
+Creates valid user password hashes, usable by (relevant) Trust0 authentication schemes
+
+Usage: trust0-password-hasher --authn-scheme <AUTHN_SCHEME>
+
+Options:
+      --authn-scheme <AUTHN_SCHEME>
+          Authentication mechanism
+          Current schemes: 'scram-sha256': SCRAM SHA256 using credentials stored in user repository
+          
+          [env: AUTHN_SCHEME=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+```
+
+Here is a simple invocation of this tool:
+
+```
+<TRUST0_REPO>/target/debug$ ./target/debug/trust0-password-hasher --authn-scheme scram-sha256
+Trust0 SDP Password Hasher v0.4.0-alpha
+Username: user1
+Password: 
+30nasGxfW9JzThsjsGSutayNhTgRNVxkv_Qm6ZUlW2U=
 ```
 
 #### Create Root CA PKI Resources

--- a/example/example-db-user.json.m4
+++ b/example/example-db-user.json.m4
@@ -1,4 +1,4 @@
 [
-    {"userId": 100, "name": "User100", "status":  "active", "roles": [50, 51]},
-    {"userId": 101, "name": "User101", "status":  "active", "roles": []}
+    {"userId": 100, "userName": "user1", "password": "30nasGxfW9JzThsjsGSutayNhTgRNVxkv_Qm6ZUlW2U=", "name": "User100", "status":  "active", "roles": [50, 51]},
+    {"userId": 101, "userName": null, "password": null, "name": "User101", "status":  "active", "roles": []}
 ]

--- a/example/run-configure.sh
+++ b/example/run-configure.sh
@@ -25,6 +25,8 @@ else
   RECONFIGURE=y
 fi
 
+read -p "If example requires secondary authentication credentials, please use \"user1\", \"pass1\""
+
 if [ "$RECONFIGURE" == 'y' ]; then
   mkdir -p "${EXAMPLE_BUILD_DIR}"
   rm -f "${EXAMPLE_CONFIG_FILE}" "${DATASOURCE_INMEMDB_ACCESS_FILE}" "${DATASOURCE_INMEMDB_SERVICE_FILE}" "${DATASOURCE_INMEMDB_ROLE_FILE}" "${DATASOURCE_INMEMDB_USER_FILE}"


### PR DESCRIPTION
### Summary

Now the gateway can be configured to enforce an additional authentication method. Currently only a SCRAM SHA256 implementation has been provided.

If enabled, an authenticated user will not be able to perform several control plane actions nor make service proxy connections.

The user can still perform some control plane actions, but otherwise will need to follow the new `login` control plane flow to log in.

The SCRAM SHA256 strategy will utilize new `user` repository fields: `username` and `password` to verify authentication.

A new common crate tool is also supplied to produce valid hashed passwords for the SCRAM SHA256 implementation. These values can be stored in the new `user` table `password` field.
