### PR TITLE
[FEAT] Signaling control plane channel added

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
 
 [[package]]
 name = "anstyle-parse"
@@ -769,9 +769,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "linked-hash-map"
@@ -945,6 +945,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -1404,9 +1410,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.112"
+version = "1.0.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d1bd37ce2324cf3bf85e5a25f96eb4baf0d5aa6eba43e7ae8958870c4ec48ed"
+checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
 dependencies = [
  "itoa",
  "ryu",
@@ -1552,12 +1558,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+checksum = "fe80ced77cbfb4cb91a94bf72b378b4b6791a0d9b7f09d0be747d1bdff4e68bd"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
  "powerfmt",
  "serde",
  "time-core",
@@ -1572,10 +1579,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This is early alpha, use with care.
 
 ### To-Do
 
-* Add Windows UDP support. Tested: macOS (Big Sur); Linux (Fedora 39), Windows (11 - TCP supported only)
+* Add Windows UDP support. Tested: macOS (Big Sur); Fedora 39, Windows 11 (TCP only)
 * Enhance gateway for runtime client certificate reissuance (on expiry or on demand)
 * Incorporate device posture trust assessment and rules processor for security enforcement
 * Build (more) testing: integration, performance, ...

--- a/crates/client/src/gateway/connection.rs
+++ b/crates/client/src/gateway/connection.rs
@@ -27,7 +27,7 @@ impl ServerConnVisitor {
         Ok(Self {
             _app_config: app_config.clone(),
             event_channel_sender: None,
-            message_processor: Box::new(ControlPlane::new(app_config.clone(), &service_mgr)),
+            message_processor: Box::new(ControlPlane::new(app_config.clone(), &service_mgr)?),
         })
     }
 }

--- a/crates/client/src/gateway/controller/signaling.rs
+++ b/crates/client/src/gateway/controller/signaling.rs
@@ -1,0 +1,517 @@
+mod proxy_connections;
+
+use std::collections::{HashMap, VecDeque};
+use std::ops::DerefMut;
+use std::rc::Rc;
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use anyhow::Result;
+
+use crate::gateway::controller::signaling::proxy_connections::ProxyConnectionsProcessor;
+use crate::gateway::controller::ChannelProcessor;
+use crate::service::manager::ServiceMgr;
+use trust0_common::control::pdu::MessageFrame;
+use trust0_common::control::signaling::event::{EventType, SignalEvent};
+use trust0_common::error::AppError;
+use trust0_common::logging::error;
+use trust0_common::net::tls_client::conn_std;
+use trust0_common::target;
+
+const EVENT_LOOP_CYCLE_DELAY_MSECS: u64 = 6_000;
+
+/// Process signaling control plane event messages
+pub struct SignalingController {
+    /// Channel sender for connection events
+    event_channel_sender: Option<mpsc::Sender<conn_std::ConnectionEvent>>,
+    /// Signaling event processors
+    event_processors: HashMap<EventType, Rc<Mutex<dyn SignalingEventHandler>>>,
+    /// Signaling event message inbox
+    message_inbox: Arc<Mutex<HashMap<EventType, VecDeque<SignalEvent>>>>,
+    /// Event loop processing state
+    event_loop_processing: Arc<Mutex<bool>>,
+}
+
+impl SignalingController {
+    /// SignalingController constructor
+    ///
+    /// # Arguments
+    ///
+    /// * `service_mgr` - Service manager
+    /// * `message_outbox` - Queued PDU responses to be sent to client
+    ///
+    /// # Returns
+    ///
+    /// A newly constructed [`SignalingController`] object.
+    ///
+    pub fn new(
+        service_mgr: &Arc<Mutex<dyn ServiceMgr>>,
+        message_outbox: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    ) -> Self {
+        let proxy_conns_processor = Rc::new(Mutex::new(ProxyConnectionsProcessor::new(
+            service_mgr,
+            message_outbox,
+        )));
+
+        let mut event_processors: HashMap<EventType, Rc<Mutex<dyn SignalingEventHandler>>> =
+            HashMap::new();
+        event_processors.insert(EventType::ProxyConnections, proxy_conns_processor);
+
+        Self {
+            event_channel_sender: None,
+            event_processors,
+            message_inbox: Arc::new(Mutex::new(HashMap::from([(
+                EventType::ProxyConnections,
+                VecDeque::new(),
+            )]))),
+            event_loop_processing: Arc::new(Mutex::new(false)),
+        }
+    }
+
+    /// Spawn thread to start an event loop to process signaling events
+    ///
+    /// # Arguments
+    ///
+    /// * `signal_controller` - The [`SignalingController`] to use for the event loop processor
+    /// * `loop_cycle_delay` - Duration to sleep each cycle iteration. If not supplied, uses default [`EVENT_LOOP_CYCLE_DELAY_MSECS`].
+    ///
+    /// # Returns
+    ///
+    /// A [`Result`] indicating the success/failure of the spawning operation.
+    ///
+    pub fn spawn_event_loop(
+        signal_controller: &Arc<Mutex<SignalingController>>,
+        loop_cycle_delay: Option<Duration>,
+    ) -> Result<(), AppError> {
+        let controller = signal_controller.clone();
+
+        thread::spawn(move || {
+            let loop_cycle_delay =
+                loop_cycle_delay.unwrap_or(Duration::from_millis(EVENT_LOOP_CYCLE_DELAY_MSECS));
+            let loop_processing = controller.lock().unwrap().event_loop_processing.clone();
+            let message_inbox = controller.lock().unwrap().message_inbox.clone();
+            let event_channel_sender = controller.lock().unwrap().event_channel_sender.clone();
+            *loop_processing.lock().unwrap() = true;
+
+            loop {
+                if !*loop_processing.lock().unwrap() {
+                    break;
+                }
+
+                for (event_type, event_processor) in &controller.lock().unwrap().event_processors {
+                    if let Err(err) = event_processor.lock().unwrap().on_loop_cycle(
+                        message_inbox
+                            .lock()
+                            .unwrap()
+                            .get_mut(event_type)
+                            .unwrap()
+                            .drain(..)
+                            .collect::<VecDeque<_>>(),
+                    ) {
+                        error(&target!(), &format!("{:?}", &err));
+
+                        *loop_processing.lock().unwrap() = false;
+
+                        if let Err(err) = event_channel_sender
+                            .as_ref()
+                            .unwrap()
+                            .send(conn_std::ConnectionEvent::Closing)
+                        {
+                            println!("Error sending closing event: err={:?}", &err);
+                            error(
+                                &target!(),
+                                &format!("Error sending closing event: err={:?}", &err),
+                            );
+                        }
+                    }
+                }
+
+                thread::sleep(loop_cycle_delay);
+            }
+        });
+
+        Ok(())
+    }
+}
+
+unsafe impl Send for SignalingController {}
+
+impl Drop for SignalingController {
+    fn drop(&mut self) {
+        *self.event_loop_processing.lock().unwrap() = false;
+    }
+}
+
+impl ChannelProcessor for SignalingController {
+    fn on_connected(
+        &mut self,
+        event_channel_sender: mpsc::Sender<conn_std::ConnectionEvent>,
+    ) -> Result<(), AppError> {
+        self.event_channel_sender = Some(event_channel_sender.clone());
+
+        Ok(())
+    }
+
+    fn process_outbound_messages(&mut self) -> Result<(), AppError> {
+        Ok(())
+    }
+
+    fn process_inbound_message(&mut self, message: MessageFrame) -> Result<(), AppError> {
+        let signal_event: SignalEvent = message.try_into()?;
+        if EventType::General == signal_event.event_type {
+            return Ok(());
+        }
+        self.message_inbox
+            .lock()
+            .unwrap()
+            .deref_mut()
+            .get_mut(&signal_event.event_type)
+            .unwrap()
+            .push_back(signal_event);
+
+        Ok(())
+    }
+}
+
+/// Control plane signaling event handler
+pub trait SignalingEventHandler {
+    /// Event loop cycle tick handler. Will pass in any available messages (appropriate for event type)
+    ///
+    /// # Arguments
+    ///
+    /// * `signal_events` - Signal message events (should be appropriate for given signaling event type)
+    ///
+    /// # Returns
+    ///
+    /// A [`Result`] indicating success/failure of the processing operation. Upon failure, the client session
+    /// (control plane and all service proxy connections) will be shut down.
+    ///
+    fn on_loop_cycle(&mut self, signal_events: VecDeque<SignalEvent>) -> Result<(), AppError>;
+}
+
+/// Unit tests
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::service::manager::tests::MockSvcMgr;
+    use mockall::{mock, predicate};
+    use serde_json::json;
+    use std::sync::mpsc;
+    use trust0_common::control;
+    use trust0_common::control::pdu::ControlChannel;
+
+    // mocks
+    // =====
+
+    mock! {
+        pub SigEvtHandler {}
+        impl SignalingEventHandler for SigEvtHandler {
+            fn on_loop_cycle(&mut self, signal_events: VecDeque<SignalEvent>) -> Result<(), AppError>;
+        }
+    }
+
+    // utils
+    // =====
+
+    fn create_controller(
+        event_channel_sender: mpsc::Sender<conn_std::ConnectionEvent>,
+        proxy_connections_processor: Rc<Mutex<dyn SignalingEventHandler>>,
+    ) -> Result<SignalingController, AppError> {
+        Ok(SignalingController {
+            event_channel_sender: Some(event_channel_sender),
+            event_processors: HashMap::from([(
+                EventType::ProxyConnections,
+                proxy_connections_processor,
+            )]),
+            message_inbox: Arc::new(Mutex::new(HashMap::from([(
+                EventType::ProxyConnections,
+                VecDeque::new(),
+            )]))),
+            event_loop_processing: Arc::new(Mutex::new(false)),
+        })
+    }
+
+    // tests
+    // =====
+
+    #[test]
+    fn sigcontrol_new() {
+        let service_mgr: Arc<Mutex<dyn ServiceMgr>> = Arc::new(Mutex::new(MockSvcMgr::new()));
+        let _ = SignalingController::new(&service_mgr, Arc::new(Mutex::new(VecDeque::new())));
+    }
+
+    #[test]
+    fn sigcontrol_spawn_event_loop_when_inbox_has_message() {
+        let mut proxy_conns_processor = MockSigEvtHandler::new();
+        proxy_conns_processor
+            .expect_on_loop_cycle()
+            .with(predicate::always())
+            .return_once(|_| Ok(()));
+        let controller = create_controller(
+            mpsc::channel().0,
+            Rc::new(Mutex::new(proxy_conns_processor)),
+        )
+        .unwrap();
+
+        let event_loop_processing = controller.event_loop_processing.clone();
+        let message_inbox = controller.message_inbox.clone();
+        message_inbox
+            .lock()
+            .unwrap()
+            .get_mut(&EventType::ProxyConnections)
+            .unwrap()
+            .push_back(SignalEvent::new(
+                control::pdu::CODE_OK,
+                &None,
+                &EventType::ProxyConnections,
+                &Some(json!([])),
+            ));
+
+        let controller = Arc::new(Mutex::new(controller));
+
+        let result = SignalingController::spawn_event_loop(
+            &controller.clone(),
+            Some(Duration::from_millis(500)),
+        );
+
+        if let Err(err) = result {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+
+        thread::sleep(Duration::from_millis(250));
+
+        if !*event_loop_processing.lock().unwrap() {
+            panic!("Event loop processing state not active");
+        }
+
+        *event_loop_processing.lock().unwrap() = false;
+
+        assert!(message_inbox
+            .lock()
+            .unwrap()
+            .get(&EventType::ProxyConnections)
+            .is_some());
+        assert!(message_inbox
+            .lock()
+            .unwrap()
+            .get(&EventType::ProxyConnections)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn sigcontrol_spawn_event_loop_when_inbox_no_message() {
+        let mut proxy_conns_processor = MockSigEvtHandler::new();
+        proxy_conns_processor
+            .expect_on_loop_cycle()
+            .with(predicate::always())
+            .return_once(|_| Ok(()));
+        let controller = create_controller(
+            mpsc::channel().0,
+            Rc::new(Mutex::new(proxy_conns_processor)),
+        )
+        .unwrap();
+
+        let event_loop_processing = controller.event_loop_processing.clone();
+        let message_inbox = controller.message_inbox.clone();
+
+        let controller = Arc::new(Mutex::new(controller));
+
+        let result = SignalingController::spawn_event_loop(
+            &controller.clone(),
+            Some(Duration::from_millis(500)),
+        );
+
+        if let Err(err) = result {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+
+        thread::sleep(Duration::from_millis(250));
+
+        if !*event_loop_processing.lock().unwrap() {
+            panic!("Event loop processing state not active");
+        }
+
+        *event_loop_processing.lock().unwrap() = false;
+
+        assert!(message_inbox
+            .lock()
+            .unwrap()
+            .get(&EventType::ProxyConnections)
+            .is_some());
+        assert!(message_inbox
+            .lock()
+            .unwrap()
+            .get(&EventType::ProxyConnections)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn sigcontrol_spawn_event_loop_when_inbox_no_message_and_process_err() {
+        let mut proxy_conns_processor = MockSigEvtHandler::new();
+        proxy_conns_processor
+            .expect_on_loop_cycle()
+            .with(predicate::always())
+            .return_once(|_| Err(AppError::General("process error".to_string())));
+        let event_channel = mpsc::channel();
+        let controller =
+            create_controller(event_channel.0, Rc::new(Mutex::new(proxy_conns_processor))).unwrap();
+
+        let event_loop_processing = controller.event_loop_processing.clone();
+        let message_inbox = controller.message_inbox.clone();
+
+        let controller = Arc::new(Mutex::new(controller));
+
+        let result = SignalingController::spawn_event_loop(
+            &controller.clone(),
+            Some(Duration::from_millis(500)),
+        );
+
+        if let Err(err) = result {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+
+        thread::sleep(Duration::from_millis(250));
+
+        match event_channel.1.try_recv() {
+            Ok(event) => {
+                if let conn_std::ConnectionEvent::Closing = event {
+                } else {
+                    panic!("Unexpected conn event recvd: evt={:?}", event)
+                }
+            }
+            Err(err) => {
+                panic!("Unexpected conn event channel result: err={:?}", &err);
+            }
+        }
+
+        if *event_loop_processing.lock().unwrap() {
+            *event_loop_processing.lock().unwrap() = false;
+            panic!("Event loop processing state not disabled");
+        }
+
+        assert!(message_inbox
+            .lock()
+            .unwrap()
+            .get(&EventType::ProxyConnections)
+            .is_some());
+        assert!(message_inbox
+            .lock()
+            .unwrap()
+            .get(&EventType::ProxyConnections)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn sigcontrol_process_inbound_message_when_wrong_control_channel() {
+        let mut controller = create_controller(
+            mpsc::channel().0,
+            Rc::new(Mutex::new(MockSigEvtHandler::new())),
+        )
+        .unwrap();
+
+        let msg_frame = MessageFrame::new(
+            ControlChannel::Management,
+            control::pdu::CODE_OK,
+            &Some("msg1".to_string()),
+            &None,
+            &Some(json!([])),
+        );
+
+        let result = controller.process_inbound_message(msg_frame);
+
+        if let Ok(()) = result {
+            panic!("Unexpected successful result");
+        }
+    }
+
+    #[test]
+    fn sigcontrol_process_inbound_message_when_event_type_is_general() {
+        let mut controller = create_controller(
+            mpsc::channel().0,
+            Rc::new(Mutex::new(MockSigEvtHandler::new())),
+        )
+        .unwrap();
+
+        let msg_frame = MessageFrame::new(
+            ControlChannel::Signaling,
+            control::pdu::CODE_OK,
+            &None,
+            &Some(json!(EventType::General)),
+            &Some(json!([])),
+        );
+
+        let result = controller.process_inbound_message(msg_frame);
+
+        if let Err(err) = result {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+    }
+
+    #[test]
+    fn sigcontrol_process_inbound_message_when_event_type_is_proxy_conns() {
+        let mut controller = create_controller(
+            mpsc::channel().0,
+            Rc::new(Mutex::new(MockSigEvtHandler::new())),
+        )
+        .unwrap();
+
+        let msg_frame = MessageFrame::new(
+            ControlChannel::Signaling,
+            control::pdu::CODE_OK,
+            &None,
+            &Some(json!(EventType::ProxyConnections)),
+            &Some(json!([])),
+        );
+
+        assert!(controller
+            .message_inbox
+            .lock()
+            .unwrap()
+            .get(&EventType::ProxyConnections)
+            .is_some());
+        assert!(controller
+            .message_inbox
+            .lock()
+            .unwrap()
+            .get(&EventType::ProxyConnections)
+            .unwrap()
+            .is_empty());
+
+        let result = controller.process_inbound_message(msg_frame);
+
+        if let Err(err) = result {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+
+        assert_eq!(
+            controller
+                .message_inbox
+                .lock()
+                .unwrap()
+                .get(&EventType::ProxyConnections)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            *controller
+                .message_inbox
+                .lock()
+                .unwrap()
+                .get(&EventType::ProxyConnections)
+                .unwrap()
+                .get(0)
+                .unwrap(),
+            SignalEvent::new(
+                control::pdu::CODE_OK,
+                &None,
+                &EventType::ProxyConnections,
+                &Some(json!([])),
+            )
+        );
+    }
+}

--- a/crates/client/src/gateway/controller/signaling/proxy_connections.rs
+++ b/crates/client/src/gateway/controller/signaling/proxy_connections.rs
@@ -1,0 +1,543 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use serde_json::Value;
+use serde_json::Value::Array;
+
+use crate::gateway::controller::signaling::SignalingEventHandler;
+use crate::service::manager::ServiceMgr;
+use crate::service::proxy::proxy_base::ProxyConnAddrs;
+use trust0_common::control::signaling::event::{EventType, ProxyConnection, SignalEvent};
+use trust0_common::error::AppError;
+use trust0_common::error::AppError::General;
+use trust0_common::logging::{error, warn};
+use trust0_common::{control, target};
+
+const LIVENESS_MAX_CONSECUTIVE_MISSING_CONNECTION_PROBES: u16 = 5;
+const LIVENESS_MAX_CONSECUTIVE_MISSING_SIGNAL_PROBES: u16 = 5;
+
+/// Process inbound proxy connections signaling message events
+pub struct ProxyConnectionsProcessor {
+    /// Service manager
+    service_mgr: Arc<Mutex<dyn ServiceMgr>>,
+    /// Queued PDU responses to be sent to client
+    message_outbox: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    /// Missing connection bind addresses
+    /// key: (client bind address, gateway bind address)
+    /// value: (missing count, service ID, proxy key)
+    missing_connection_binds: HashMap<ProxyConnAddrs, (u16, u64, String)>,
+    /// Missing signal event probes
+    missing_signal_probes: u16,
+}
+
+impl ProxyConnectionsProcessor {
+    /// ProxyConnectionsProcessor constructor
+    ///
+    /// # Arguments
+    ///
+    /// * `service_mgr` - Service manager
+    /// * `message_outbox` - Queued PDU responses to be sent to client
+    ///
+    /// # Returns
+    ///
+    /// A newly constructed [`ProxyConnectionsProcessor`] object.
+    ///
+    pub fn new(
+        service_mgr: &Arc<Mutex<dyn ServiceMgr>>,
+        message_outbox: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    ) -> Self {
+        Self {
+            service_mgr: service_mgr.clone(),
+            message_outbox,
+            missing_connection_binds: HashMap::new(),
+            missing_signal_probes: 0,
+        }
+    }
+
+    /// Gather proxy keys/addresses for service proxy connections.
+    ///
+    /// # Returns
+    ///
+    /// A map of (`service ID`, (`service name`, Vec<(`proxy key`, `proxy addrs`)>)) corresponding to proxy connections.
+    ///
+    fn current_proxy_keys(&self) -> HashMap<u64, (String, Vec<(String, ProxyConnAddrs)>)> {
+        let service_proxies = self.service_mgr.lock().unwrap().get_service_proxies();
+        service_proxies
+            .iter()
+            .map(|service_proxy| {
+                let service_proxy = service_proxy.lock().unwrap();
+                let service = service_proxy.get_service();
+                (
+                    service.service_id,
+                    (service.name.clone(), service_proxy.get_proxy_keys().clone()),
+                )
+            })
+            .collect::<HashMap<u64, (String, Vec<(String, ProxyConnAddrs)>)>>()
+    }
+
+    /// Process inbound proxy connections signal event
+    ///
+    /// # Arguments
+    ///
+    /// * `service_mgr` - Service manager
+    /// * `proxy_keys` - Current proxy keys and address binds
+    /// * `signal_event` - Proxy connections signal event
+    ///
+    /// # Returns
+    ///
+    /// A [`Result`] indicating success/failure of the processing operation.
+    ///
+    #[allow(clippy::type_complexity)]
+    fn process_inbound_event(
+        &mut self,
+        service_mgr: &Arc<Mutex<dyn ServiceMgr>>,
+        proxy_keys: &HashMap<u64, (String, Vec<(String, ProxyConnAddrs)>)>,
+        signal_event: SignalEvent,
+    ) -> Result<(), AppError> {
+        let mut proxy_context_map = HashMap::new();
+        let mut missing_conn_binds = HashMap::new();
+        let mut shutdown_conn_binds = Vec::new();
+
+        // Set up client/gateway connection address sets
+        let client_conn_addrs: HashSet<ProxyConnAddrs> = match signal_event.data {
+            None => HashSet::new(),
+            Some(data) => HashSet::from_iter(
+                ProxyConnection::from_serde_value(&data)?
+                    .iter()
+                    .flat_map(|proxy_conn| proxy_conn.binds.clone())
+                    .map(|proxy_addrs| {
+                        (
+                            #[allow(clippy::get_first)]
+                            proxy_addrs.get(0).as_ref().unwrap().to_string(),
+                            proxy_addrs.get(1).as_ref().unwrap().to_string(),
+                        )
+                    })
+                    .collect::<HashSet<ProxyConnAddrs>>(),
+            ),
+        };
+
+        let mut gateway_conn_addrs: HashSet<ProxyConnAddrs> = HashSet::new();
+        for (service_id, (_, service_proxy_keys)) in proxy_keys {
+            for service_proxy_key in service_proxy_keys {
+                proxy_context_map.insert(
+                    service_proxy_key.1.clone(),
+                    (service_id, service_proxy_key.0.clone()),
+                );
+                gateway_conn_addrs.insert(service_proxy_key.1.clone());
+            }
+        }
+
+        // Determine missing connections from client set
+        for missing_conn_bind in gateway_conn_addrs.difference(&client_conn_addrs) {
+            match self.missing_connection_binds.get(missing_conn_bind) {
+                None => {
+                    let (service_id, proxy_key) =
+                        proxy_context_map.get(missing_conn_bind).unwrap().clone();
+                    missing_conn_binds.insert(
+                        missing_conn_bind.clone(),
+                        (1, *service_id, proxy_key.clone()),
+                    );
+                }
+                Some((count, service_id, proxy_key)) => {
+                    let missing_count = count + 1;
+                    if missing_count >= LIVENESS_MAX_CONSECUTIVE_MISSING_CONNECTION_PROBES {
+                        shutdown_conn_binds.push((
+                            *service_id,
+                            proxy_key.clone(),
+                            missing_conn_bind.clone(),
+                        ));
+                    } else {
+                        missing_conn_binds.insert(
+                            missing_conn_bind.clone(),
+                            (missing_count, *service_id, proxy_key.clone()),
+                        );
+                    }
+                }
+            }
+        }
+
+        self.missing_connection_binds = missing_conn_binds;
+
+        // Shutdown dead connections
+        let mut errors: Vec<String> = vec![];
+
+        for shutdown_conn_bind in &shutdown_conn_binds {
+            warn(
+                &target!(),
+                &format!(
+                    "Shutting down dead proxy connection: svc_id={}, proxy_addrs={:?}",
+                    shutdown_conn_bind.0, shutdown_conn_bind.1
+                ),
+            );
+
+            if let Err(err) = service_mgr
+                .lock()
+                .unwrap()
+                .shutdown_connection(shutdown_conn_bind.0, &shutdown_conn_bind.1)
+            {
+                errors.push(format!("{:?}", &err));
+            }
+        }
+
+        if !errors.is_empty() {
+            Err(General(format!(
+                "Error shutting down connection(s): errs={}",
+                errors.join(", ")
+            )))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Process outbound proxy connections signal event
+    ///
+    /// # Arguments
+    ///
+    /// * `proxy_keys` - Current proxy keys and address binds
+    ///
+    /// # Returns
+    ///
+    /// A [`Result`] indicating success/failure of the processing operation.
+    ///
+    #[allow(clippy::type_complexity)]
+    fn process_outbound_event(
+        &mut self,
+        proxy_keys: &HashMap<u64, (String, Vec<(String, ProxyConnAddrs)>)>,
+    ) -> Result<(), AppError> {
+        let mut proxy_connections: Vec<Value> = Vec::new();
+
+        for (service_name, service_proxy_keys) in proxy_keys.values() {
+            proxy_connections.push(
+                ProxyConnection::new(
+                    service_name.as_str(),
+                    service_proxy_keys
+                        .iter()
+                        .map(|k| vec![k.1 .0.to_string(), k.1 .1.to_string()])
+                        .collect::<Vec<Vec<String>>>(),
+                )
+                .try_into()
+                .unwrap(),
+            );
+        }
+
+        self.message_outbox.lock().unwrap().push_back(
+            control::pdu::MessageFrame::new(
+                control::pdu::ControlChannel::Signaling,
+                control::pdu::CODE_OK,
+                &None,
+                &Some(serde_json::to_value(EventType::ProxyConnections).unwrap()),
+                &Some(Array(proxy_connections)),
+            )
+            .build_pdu()?,
+        );
+
+        Ok(())
+    }
+}
+
+unsafe impl Send for ProxyConnectionsProcessor {}
+
+impl SignalingEventHandler for ProxyConnectionsProcessor {
+    fn on_loop_cycle(&mut self, signal_events: VecDeque<SignalEvent>) -> Result<(), AppError> {
+        let proxy_keys = self.current_proxy_keys();
+        let service_mgr = self.service_mgr.clone();
+
+        // Process inbound message(s)
+        if !signal_events.is_empty() {
+            self.missing_signal_probes = 0;
+
+            for signal_event in signal_events {
+                if let Err(err) =
+                    self.process_inbound_event(&service_mgr, &proxy_keys, signal_event)
+                {
+                    error(&target!(), &format!("{:?}", &err));
+                }
+            }
+        }
+        // Process missing signal event
+        else {
+            self.missing_signal_probes += 1;
+            if self.missing_signal_probes >= LIVENESS_MAX_CONSECUTIVE_MISSING_SIGNAL_PROBES {
+                return Err(AppError::General(
+                    "Gateway not responsive, closing all connections".to_string(),
+                ));
+            }
+        }
+
+        // Process outbound message
+        self.process_outbound_event(&proxy_keys)
+    }
+}
+
+/// Unit tests
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::service::manager::tests::MockSvcMgr;
+    use crate::service::proxy::proxy_base::tests::MockCliSvcProxyVisitor;
+    use mockall::predicate;
+    use serde_json::json;
+    use trust0_common::control::pdu;
+    use trust0_common::control::pdu::ControlChannel;
+    use trust0_common::model;
+
+    // utils
+    // =====
+
+    fn create_processor(
+        service_mgr: Arc<Mutex<dyn ServiceMgr>>,
+        message_outbox: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    ) -> Result<ProxyConnectionsProcessor, AppError> {
+        Ok(ProxyConnectionsProcessor {
+            service_mgr,
+            message_outbox,
+            missing_connection_binds: HashMap::new(),
+            missing_signal_probes: 0,
+        })
+    }
+
+    // tests
+    // =====
+
+    #[test]
+    fn proxyconnproc_new() {
+        let service_mgr: Arc<Mutex<dyn ServiceMgr>> = Arc::new(Mutex::new(MockSvcMgr::new()));
+        let processor =
+            ProxyConnectionsProcessor::new(&service_mgr, Arc::new(Mutex::new(VecDeque::new())));
+
+        assert!(processor.missing_connection_binds.is_empty());
+        assert_eq!(processor.missing_signal_probes, 0);
+    }
+
+    #[test]
+    fn proxyconnproc_current_proxy_keys() {
+        let mut service_mgr = MockSvcMgr::new();
+        let mut service_proxy = MockCliSvcProxyVisitor::new();
+        service_proxy
+            .expect_get_service()
+            .times(1)
+            .return_once(|| model::service::Service {
+                service_id: 200,
+                name: "Service200".to_string(),
+                transport: model::service::Transport::TCP,
+                host: "localhost".to_string(),
+                port: 8200,
+            });
+        service_proxy
+            .expect_get_proxy_keys()
+            .times(1)
+            .return_once(move || {
+                vec![(
+                    "key1".to_string(),
+                    ("addr1".to_string(), "addr2".to_string()),
+                )]
+            });
+        service_mgr
+            .expect_get_service_proxies()
+            .times(1)
+            .return_once(move || vec![Arc::new(Mutex::new(service_proxy))]);
+
+        let processor = create_processor(
+            Arc::new(Mutex::new(service_mgr)),
+            Arc::new(Mutex::new(VecDeque::new())),
+        );
+
+        let proxy_keys = processor.unwrap().current_proxy_keys();
+
+        assert!(proxy_keys.contains_key(&200));
+        assert_eq!(
+            *proxy_keys.get(&200).unwrap(),
+            (
+                "Service200".to_string(),
+                vec![(
+                    "key1".to_string(),
+                    ("addr1".to_string(), "addr2".to_string())
+                )]
+            )
+        );
+    }
+
+    #[test]
+    fn proxyconnproc_on_loop_cycle_when_1_found_and_1_missing_and_1_dead() {
+        let mut service_mgr = MockSvcMgr::new();
+        let mut service_proxy = MockCliSvcProxyVisitor::new();
+        service_proxy
+            .expect_get_service()
+            .times(1)
+            .return_once(|| model::service::Service {
+                service_id: 200,
+                name: "Service200".to_string(),
+                transport: model::service::Transport::TCP,
+                host: "localhost".to_string(),
+                port: 8200,
+            });
+        service_proxy
+            .expect_get_proxy_keys()
+            .times(1)
+            .return_once(move || {
+                vec![
+                    (
+                        "key1".to_string(),
+                        ("addr1".to_string(), "addr2".to_string()),
+                    ),
+                    (
+                        "key2".to_string(),
+                        ("addr3".to_string(), "addr4".to_string()),
+                    ),
+                    (
+                        "key3".to_string(),
+                        ("addr5".to_string(), "addr6".to_string()),
+                    ),
+                ]
+            });
+        service_mgr
+            .expect_get_service_proxies()
+            .times(1)
+            .return_once(move || vec![Arc::new(Mutex::new(service_proxy))]);
+        service_mgr
+            .expect_shutdown_connection()
+            .with(predicate::eq(200), predicate::eq("key3".to_string()))
+            .times(1)
+            .return_once(|_, _| Ok(()));
+
+        let mut processor = create_processor(
+            Arc::new(Mutex::new(service_mgr)),
+            Arc::new(Mutex::new(VecDeque::new())),
+        )
+        .unwrap();
+        processor.missing_signal_probes = 1;
+        processor.missing_connection_binds.insert(
+            ("addr5".to_string(), "addr6".to_string()),
+            (
+                LIVENESS_MAX_CONSECUTIVE_MISSING_CONNECTION_PROBES - 1,
+                200,
+                "key3".to_string(),
+            ),
+        );
+
+        let result = processor.on_loop_cycle(VecDeque::from(vec![SignalEvent::new(
+            control::pdu::CODE_OK,
+            &None,
+            &EventType::ProxyConnections,
+            &Some(json!([
+                {
+                    "service_name": "Service200",
+                    "binds": [["addr1","addr2"]]
+                },
+            ])),
+        )]));
+
+        if let Err(err) = result {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+
+        assert_eq!(processor.missing_signal_probes, 0);
+        assert_eq!(processor.missing_connection_binds.len(), 1);
+        assert!(processor
+            .missing_connection_binds
+            .get(&("addr3".to_string(), "addr4".to_string()))
+            .is_some());
+        assert_eq!(
+            *processor
+                .missing_connection_binds
+                .get(&("addr3".to_string(), "addr4".to_string()))
+                .unwrap(),
+            (1, 200, "key2".to_string())
+        );
+        assert_eq!(processor.message_outbox.lock().unwrap().len(), 1);
+
+        let mut message = VecDeque::from(
+            processor
+                .message_outbox
+                .lock()
+                .unwrap()
+                .get(0)
+                .unwrap()
+                .clone(),
+        );
+        let message_result = pdu::MessageFrame::consume_next_pdu(&mut message);
+        assert!(message_result.is_ok());
+        let message_frame = message_result.unwrap();
+        assert!(message_frame.is_some());
+        assert_eq!(
+            message_frame.unwrap(),
+            pdu::MessageFrame::new(
+                ControlChannel::Signaling,
+                pdu::CODE_OK,
+                &None,
+                &Some(serde_json::to_value(EventType::ProxyConnections).unwrap()),
+                &Some(json!([
+                    {
+                        "service_name": "Service200",
+                        "binds": [
+                            ["addr1", "addr2"],
+                            ["addr3", "addr4"],
+                            ["addr5", "addr6"],
+                        ],
+                    },
+                ])),
+            ),
+        );
+    }
+
+    #[test]
+    fn proxyconnproc_on_loop_cycle_when_client_dead() {
+        let mut service_mgr = MockSvcMgr::new();
+        let mut service_proxy = MockCliSvcProxyVisitor::new();
+        service_proxy
+            .expect_get_service()
+            .times(1)
+            .return_once(|| model::service::Service {
+                service_id: 200,
+                name: "Service200".to_string(),
+                transport: model::service::Transport::TCP,
+                host: "localhost".to_string(),
+                port: 8200,
+            });
+        service_proxy
+            .expect_get_proxy_keys()
+            .times(1)
+            .return_once(move || {
+                vec![
+                    (
+                        "key1".to_string(),
+                        ("addr1".to_string(), "addr2".to_string()),
+                    ),
+                    (
+                        "key2".to_string(),
+                        ("addr3".to_string(), "addr4".to_string()),
+                    ),
+                    (
+                        "key3".to_string(),
+                        ("addr5".to_string(), "addr6".to_string()),
+                    ),
+                ]
+            });
+        service_mgr
+            .expect_get_service_proxies()
+            .times(1)
+            .return_once(move || vec![Arc::new(Mutex::new(service_proxy))]);
+        service_mgr.expect_shutdown_connection().never();
+
+        let mut processor = create_processor(
+            Arc::new(Mutex::new(service_mgr)),
+            Arc::new(Mutex::new(VecDeque::new())),
+        )
+        .unwrap();
+        processor.missing_signal_probes = LIVENESS_MAX_CONSECUTIVE_MISSING_SIGNAL_PROBES - 1;
+
+        let result = processor.on_loop_cycle(VecDeque::new());
+
+        if let Ok(()) = result {
+            panic!("Unexpected successful result");
+        }
+
+        assert_eq!(
+            processor.missing_signal_probes,
+            LIVENESS_MAX_CONSECUTIVE_MISSING_SIGNAL_PROBES
+        );
+        assert_eq!(processor.missing_connection_binds.len(), 0);
+        assert!(processor.message_outbox.lock().unwrap().is_empty());
+    }
+}

--- a/crates/common/src/bin/trust0-client-installer/main.rs
+++ b/crates/common/src/bin/trust0-client-installer/main.rs
@@ -146,14 +146,7 @@ pub mod tests {
             );
         }
         let ca_root_cert_file_meta = ca_root_cert_file_meta.unwrap();
-        #[cfg(not(windows))]
-        {
-            assert_eq!(ca_root_cert_file_meta.len(), 1834);
-        }
-        #[cfg(windows)]
-        {
-            assert_eq!(ca_root_cert_file_meta.len(), 1864);
-        }
+        assert_eq!(ca_root_cert_file_meta.len(), 1834); // with CRLF, use 1864
 
         // client binary file
         let client_binary_file_meta = fs::metadata(dest_client_binary_file_path.as_path());
@@ -164,14 +157,7 @@ pub mod tests {
             );
         }
         let client_binary_file_meta = client_binary_file_meta.unwrap();
-        #[cfg(not(windows))]
-        {
-            assert_eq!(client_binary_file_meta.len(), 110);
-        }
-        #[cfg(windows)]
-        {
-            assert_eq!(client_binary_file_meta.len(), 116);
-        }
+        assert_eq!(client_binary_file_meta.len(), 110); // with CRLF, use 116
 
         // client key file
         let client_key_file_meta = fs::metadata(dest_client_key_file_path.as_path());
@@ -182,14 +168,7 @@ pub mod tests {
             );
         }
         let client_key_file_meta = client_key_file_meta.unwrap();
-        #[cfg(not(windows))]
-        {
-            assert_eq!(client_key_file_meta.len(), 3272);
-        }
-        #[cfg(windows)]
-        {
-            assert_eq!(client_key_file_meta.len(), 3324);
-        }
+        assert_eq!(client_key_file_meta.len(), 3272); // with CRLF, use 3324
 
         // client certificate file
         let client_cert_file_meta = fs::metadata(dest_client_cert_file_path.as_path());
@@ -200,14 +179,7 @@ pub mod tests {
             );
         }
         let client_cert_file_meta = client_cert_file_meta.unwrap();
-        #[cfg(not(windows))]
-        {
-            assert_eq!(client_cert_file_meta.len(), 1911);
-        }
-        #[cfg(windows)]
-        {
-            assert_eq!(client_cert_file_meta.len(), 1942);
-        }
+        assert_eq!(client_cert_file_meta.len(), 1911); // with CRLF, use 1942
 
         // client config file
         let client_config_file_meta = fs::metadata(dest_client_config_file_path.as_path());

--- a/crates/common/src/control/mod.rs
+++ b/crates/common/src/control/mod.rs
@@ -1,2 +1,3 @@
 pub mod management;
-pub mod message;
+pub mod pdu;
+pub mod signaling;

--- a/crates/common/src/control/signaling/event.rs
+++ b/crates/common/src/control/signaling/event.rs
@@ -238,6 +238,7 @@ mod tests {
     #[test]
     fn proxyconn_from_serde_value_when_valid_connections_list() {
         let proxy_conns_json =
+
             json!([{"service_name": "svc1", "binds": [["b0","b1"],["b2","b3"]]}]);
 
         match ProxyConnection::from_serde_value(&proxy_conns_json) {

--- a/crates/common/src/control/signaling/event.rs
+++ b/crates/common/src/control/signaling/event.rs
@@ -238,7 +238,6 @@ mod tests {
     #[test]
     fn proxyconn_from_serde_value_when_valid_connections_list() {
         let proxy_conns_json =
-
             json!([{"service_name": "svc1", "binds": [["b0","b1"],["b2","b3"]]}]);
 
         match ProxyConnection::from_serde_value(&proxy_conns_json) {

--- a/crates/common/src/control/signaling/event.rs
+++ b/crates/common/src/control/signaling/event.rs
@@ -1,0 +1,300 @@
+use std::borrow::Borrow;
+
+use serde_derive::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::control::pdu::{ControlChannel, MessageFrame};
+use crate::error::AppError;
+
+/// Signaling message event type
+#[derive(Serialize, Deserialize, Clone, Default, Debug, Eq, Hash, PartialEq)]
+pub enum EventType {
+    #[default]
+    General,
+    ProxyConnections,
+}
+
+/// Signaling control plane channel message event
+#[derive(Serialize, Deserialize, Clone, Default, Debug, PartialEq)]
+pub struct SignalEvent {
+    /// Indicates well-known code status for event
+    pub code: u16,
+    /// If necessary, contains a top-level message
+    pub message: Option<String>,
+    /// Type of message event
+    pub event_type: EventType,
+    /// Event data (different depending on message event type)
+    pub data: Option<Value>,
+}
+
+impl SignalEvent {
+    /// Message constructor
+    ///
+    /// # Arguments
+    ///
+    /// * `code` - Well-known code status for event
+    /// * `message` - (optional) Top-level response message
+    /// * `event_type` - Corresponding message event type
+    /// * `data` - (optional) Event data object (generic as is different per event type)
+    ///
+    /// # Returns
+    ///
+    /// A newly constructed [`SignalEvent`] object.
+    ///
+    pub fn new(
+        code: u16,
+        message: &Option<String>,
+        event_type: &EventType,
+        data: &Option<Value>,
+    ) -> Self {
+        Self {
+            code,
+            message: message.clone(),
+            event_type: event_type.clone(),
+            data: data.clone(),
+        }
+    }
+}
+
+impl TryInto<MessageFrame> for SignalEvent {
+    type Error = AppError;
+
+    fn try_into(self) -> Result<MessageFrame, Self::Error> {
+        self.borrow().try_into()
+    }
+}
+
+impl TryInto<MessageFrame> for &SignalEvent {
+    type Error = AppError;
+
+    fn try_into(self) -> Result<MessageFrame, Self::Error> {
+        let event_type = serde_json::to_value(self.event_type.clone()).map_err(|err| {
+            AppError::GenWithMsgAndErr(
+                "Error converting EventType to Value".to_string(),
+                Box::new(err),
+            )
+        })?;
+        Ok(MessageFrame::new(
+            ControlChannel::Signaling,
+            self.code,
+            &self.message,
+            &Some(event_type),
+            &self.data,
+        ))
+    }
+}
+
+/// Active service proxy connections for connected mTLS device user
+#[derive(Serialize, Deserialize, Clone, PartialEq, Default, Debug)]
+pub struct ProxyConnection {
+    /// Service key name value
+    pub service_name: String,
+    /// List of current connection bind address pairs
+    pub binds: Vec<Vec<String>>,
+}
+
+impl ProxyConnection {
+    /// ProxyConnection constructor
+    ///
+    /// # Arguments
+    ///
+    /// * `service_name` - Service key name value
+    /// * `binds` - List of current connection bind address pairs
+    ///
+    /// # Returns
+    ///
+    /// A newly constructed [`ProxyConnection`] object.
+    ///
+    pub fn new(service_name: &str, binds: Vec<Vec<String>>) -> Self {
+        Self {
+            service_name: service_name.to_string(),
+            binds,
+        }
+    }
+
+    /// Construct proxy connection(s) from serde Value
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - A JSON object representing either a JSON array of [`ProxyConnection`] or a single [`ProxyConnection`]
+    ///
+    /// # Returns
+    ///
+    /// A [`Result`] containing a vector of corresponding [`ProxyConnection`] objects.
+    ///
+    pub fn from_serde_value(value: &Value) -> Result<Vec<ProxyConnection>, AppError> {
+        if let Value::Array(values) = &value {
+            Ok(values
+                .iter()
+                .map(|v| {
+                    serde_json::from_value(v.clone()).map_err(|err| {
+                        AppError::GenWithMsgAndErr(
+                            "Error converting serde Value to Connection".to_string(),
+                            Box::new(err),
+                        )
+                    })
+                })
+                .collect::<Result<Vec<ProxyConnection>, AppError>>()?)
+        } else {
+            Ok(vec![serde_json::from_value(value.clone()).map_err(
+                |err| {
+                    AppError::GenWithMsgAndErr(
+                        "Error converting serde Value to Connection".to_string(),
+                        Box::new(err),
+                    )
+                },
+            )?])
+        }
+    }
+}
+
+unsafe impl Send for ProxyConnection {}
+
+impl TryInto<Value> for ProxyConnection {
+    type Error = AppError;
+
+    fn try_into(self) -> Result<Value, Self::Error> {
+        self.borrow().try_into()
+    }
+}
+
+impl TryInto<Value> for &ProxyConnection {
+    type Error = AppError;
+
+    fn try_into(self) -> Result<Value, Self::Error> {
+        serde_json::to_value(self).map_err(|err| {
+            AppError::GenWithMsgAndErr(
+                "Error converting Connection to serde Value".to_string(),
+                Box::new(err),
+            )
+        })
+    }
+}
+
+/// Unit tests
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::control::pdu;
+    use serde_json::json;
+
+    #[test]
+    fn signalevt_new() {
+        let signal_event = SignalEvent::new(
+            pdu::CODE_OK,
+            &Some("msg1".to_string()),
+            &EventType::ProxyConnections,
+            &Some(Value::String("data1".to_string())),
+        );
+
+        assert_eq!(signal_event.code, pdu::CODE_OK);
+        assert!(signal_event.message.is_some());
+        assert_eq!(signal_event.message.as_ref().unwrap(), "msg1");
+        assert_eq!(signal_event.event_type, EventType::ProxyConnections);
+        assert!(signal_event.data.is_some());
+        assert_eq!(
+            signal_event.data.as_ref().unwrap().to_string(),
+            "\"data1\"".to_string()
+        );
+    }
+
+    #[test]
+    fn signalevt_try_into_message_frame() {
+        let signal_event = SignalEvent::new(
+            pdu::CODE_OK,
+            &Some("msg1".to_string()),
+            &EventType::ProxyConnections,
+            &Some(Value::String("data1".to_string())),
+        );
+
+        let result: Result<MessageFrame, AppError> = signal_event.try_into();
+        match result {
+            Ok(msg_frame) => {
+                assert_eq!(
+                    msg_frame,
+                    MessageFrame {
+                        channel: pdu::ControlChannel::Signaling,
+                        code: pdu::CODE_OK,
+                        message: Some("msg1".to_string()),
+                        context: Some(serde_json::to_value(EventType::ProxyConnections).unwrap()),
+                        data: Some(Value::String("data1".to_string())),
+                    }
+                );
+            }
+            Err(err) => panic!("Unexpected result: err={:?}", err),
+        }
+    }
+
+    #[test]
+    fn proxyconn_from_serde_value_when_invalid() {
+        let conn_json = json!({"service_name_INVALID": "svc1", "binds": [["b0","b1"],["b2","b3"]]});
+
+        match ProxyConnection::from_serde_value(&conn_json) {
+            Ok(proxies) => panic!("Unexpected successful result: conns={:?}", proxies),
+            _ => {}
+        }
+    }
+
+    #[test]
+    fn proxyconn_from_serde_value_when_valid_connections_list() {
+        let proxy_conns_json =
+            json!([{"service_name": "svc1", "binds": [["b0","b1"],["b2","b3"]]}]);
+
+        match ProxyConnection::from_serde_value(&proxy_conns_json) {
+            Ok(proxy_conns) => {
+                assert_eq!(proxy_conns.len(), 1);
+                let proxy_conn = ProxyConnection::new(
+                    "svc1",
+                    vec![
+                        vec!["b0".to_string(), "b1".to_string()],
+                        vec!["b2".to_string(), "b3".to_string()],
+                    ],
+                );
+                assert_eq!(proxy_conns, vec![proxy_conn]);
+            }
+            _ => {}
+        }
+    }
+
+    #[test]
+    fn proxyconn_from_serde_value_when_valid_connections_object() {
+        let proxy_conns_json = json!({"service_name": "svc1", "binds": [["b0","b1"],["b2","b3"]]});
+
+        match ProxyConnection::from_serde_value(&proxy_conns_json) {
+            Ok(proxy_conns) => {
+                assert_eq!(proxy_conns.len(), 1);
+                let proxy_conn = ProxyConnection::new(
+                    "svc1",
+                    vec![
+                        vec!["b0".to_string(), "b1".to_string()],
+                        vec!["b2".to_string(), "b3".to_string()],
+                    ],
+                );
+                assert_eq!(proxy_conns, vec![proxy_conn]);
+            }
+            _ => {}
+        }
+    }
+
+    #[test]
+    fn proxyconn_try_into_value() {
+        let proxy_conn = ProxyConnection::new(
+            "svc1",
+            vec![
+                vec!["b0".to_string(), "b1".to_string()],
+                vec!["b2".to_string(), "b3".to_string()],
+            ],
+        );
+
+        let result: Result<Value, AppError> = proxy_conn.try_into();
+        match result {
+            Ok(value) => {
+                assert_eq!(
+                    value,
+                    json!({"service_name": "svc1", "binds": [["b0","b1"],["b2","b3"]]})
+                );
+            }
+            Err(err) => panic!("Unexpected result: err={:?}", err),
+        }
+    }
+}

--- a/crates/common/src/control/signaling/mod.rs
+++ b/crates/common/src/control/signaling/mod.rs
@@ -1,0 +1,1 @@
+pub mod event;

--- a/crates/gateway/src/client/controller/signaling.rs
+++ b/crates/gateway/src/client/controller/signaling.rs
@@ -1,0 +1,527 @@
+mod proxy_connections;
+
+use std::collections::{HashMap, VecDeque};
+use std::ops::DerefMut;
+use std::rc::Rc;
+use std::sync::{mpsc, Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use anyhow::Result;
+
+use crate::client::controller::signaling::proxy_connections::ProxyConnectionsProcessor;
+use crate::client::controller::ChannelProcessor;
+use crate::service::manager::ServiceMgr;
+use trust0_common::control::pdu::MessageFrame;
+use trust0_common::control::signaling::event::{EventType, SignalEvent};
+use trust0_common::error::AppError;
+use trust0_common::logging::error;
+use trust0_common::net::tls_server::conn_std;
+use trust0_common::{model, target};
+
+const EVENT_LOOP_CYCLE_DELAY_MSECS: u64 = 6_000;
+
+/// Process signaling control plane event messages
+pub struct SignalingController {
+    /// Channel sender for connection events
+    event_channel_sender: mpsc::Sender<conn_std::ConnectionEvent>,
+    /// Signaling event processors
+    event_processors: HashMap<EventType, Rc<Mutex<dyn SignalingEventHandler>>>,
+    /// Signaling event message inbox
+    message_inbox: Arc<Mutex<HashMap<EventType, VecDeque<SignalEvent>>>>,
+    /// Event loop processing state
+    event_loop_processing: Arc<Mutex<bool>>,
+}
+
+impl SignalingController {
+    /// SignalingController constructor
+    ///
+    /// # Arguments
+    ///
+    /// * `service_mgr` - Service manager
+    /// * `event_channel_sender` - Channel sender for connection events
+    /// * `user` - User model object
+    /// * `message_outbox` - Queued PDU responses to be sent to client
+    ///
+    /// # Returns
+    ///
+    /// A newly constructed [`SignalingController`] object.
+    ///
+    pub fn new(
+        service_mgr: Arc<Mutex<dyn ServiceMgr>>,
+        event_channel_sender: mpsc::Sender<conn_std::ConnectionEvent>,
+        user: model::user::User,
+        message_outbox: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    ) -> Self {
+        let proxy_conns_processor = Rc::new(Mutex::new(ProxyConnectionsProcessor::new(
+            service_mgr,
+            user,
+            message_outbox,
+        )));
+
+        let mut event_processors: HashMap<EventType, Rc<Mutex<dyn SignalingEventHandler>>> =
+            HashMap::new();
+        event_processors.insert(EventType::ProxyConnections, proxy_conns_processor);
+
+        Self {
+            event_channel_sender,
+            event_processors,
+            message_inbox: Arc::new(Mutex::new(HashMap::from([(
+                EventType::ProxyConnections,
+                VecDeque::new(),
+            )]))),
+            event_loop_processing: Arc::new(Mutex::new(false)),
+        }
+    }
+
+    /// Spawn thread to start an event loop to process signaling events
+    ///
+    /// # Arguments
+    ///
+    /// * `signal_controller` - The [`SignalingController`] to use for the event loop processor
+    /// * `loop_cycle_delay` - Duration to sleep each cycle iteration. If not supplied, uses default [`EVENT_LOOP_CYCLE_DELAY_MSECS`].
+    ///
+    /// # Returns
+    ///
+    /// A [`Result`] indicating the success/failure of the spawning operation.
+    ///
+    pub fn spawn_event_loop(
+        signal_controller: &Arc<Mutex<SignalingController>>,
+        loop_cycle_delay: Option<Duration>,
+    ) -> Result<(), AppError> {
+        let controller = signal_controller.clone();
+
+        thread::spawn(move || {
+            let loop_cycle_delay =
+                loop_cycle_delay.unwrap_or(Duration::from_millis(EVENT_LOOP_CYCLE_DELAY_MSECS));
+            let loop_processing = controller.lock().unwrap().event_loop_processing.clone();
+            let message_inbox = controller.lock().unwrap().message_inbox.clone();
+            let event_channel_sender = controller.lock().unwrap().event_channel_sender.clone();
+            *loop_processing.lock().unwrap() = true;
+
+            loop {
+                if !*loop_processing.lock().unwrap() {
+                    break;
+                }
+
+                for (event_type, event_processor) in &controller.lock().unwrap().event_processors {
+                    if let Err(err) = event_processor.lock().unwrap().on_loop_cycle(
+                        message_inbox
+                            .lock()
+                            .unwrap()
+                            .get_mut(event_type)
+                            .unwrap()
+                            .drain(..)
+                            .collect::<VecDeque<_>>(),
+                    ) {
+                        error(&target!(), &format!("{:?}", &err));
+
+                        *loop_processing.lock().unwrap() = false;
+
+                        if let Err(err) =
+                            event_channel_sender.send(conn_std::ConnectionEvent::Closing)
+                        {
+                            println!("Error sending closing event: err={:?}", &err);
+                            error(
+                                &target!(),
+                                &format!("Error sending closing event: err={:?}", &err),
+                            );
+                        }
+                    }
+                }
+
+                thread::sleep(loop_cycle_delay);
+            }
+        });
+
+        Ok(())
+    }
+}
+
+unsafe impl Send for SignalingController {}
+
+impl Drop for SignalingController {
+    fn drop(&mut self) {
+        *self.event_loop_processing.lock().unwrap() = false;
+    }
+}
+
+impl ChannelProcessor for SignalingController {
+    fn process_inbound_message(&mut self, message: MessageFrame) -> Result<(), AppError> {
+        let signal_event: SignalEvent = message.try_into()?;
+        if EventType::General == signal_event.event_type {
+            return Ok(());
+        }
+        self.message_inbox
+            .lock()
+            .unwrap()
+            .deref_mut()
+            .get_mut(&signal_event.event_type)
+            .unwrap()
+            .push_back(signal_event);
+
+        Ok(())
+    }
+
+    fn is_authenticated(&self) -> Option<bool> {
+        None
+    }
+}
+
+/// Control plane signaling event handler
+pub trait SignalingEventHandler {
+    /// Event loop cycle tick handler. Will pass in any available messages (appropriate for event type)
+    ///
+    /// # Arguments
+    ///
+    /// * `signal_events` - Signal message events (should be appropriate for given signaling event type)
+    ///
+    /// # Returns
+    ///
+    /// A [`Result`] indicating success/failure of the processing operation. Upon failure, the client session
+    /// (control plane and all service proxy connections) will be shut down.
+    ///
+    fn on_loop_cycle(&mut self, signal_events: VecDeque<SignalEvent>) -> Result<(), AppError>;
+}
+
+/// Unit tests
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::client::controller::tests::create_user;
+    use crate::service::manager::tests::MockSvcMgr;
+    use mockall::{mock, predicate};
+    use serde_json::json;
+    use std::sync::mpsc;
+    use trust0_common::control;
+    use trust0_common::control::pdu::ControlChannel;
+
+    // mocks
+    // =====
+
+    mock! {
+        pub SigEvtHandler {}
+        impl SignalingEventHandler for SigEvtHandler {
+            fn on_loop_cycle(&mut self, signal_events: VecDeque<SignalEvent>) -> Result<(), AppError>;
+        }
+    }
+
+    // utils
+    // =====
+
+    fn create_controller(
+        event_channel_sender: mpsc::Sender<conn_std::ConnectionEvent>,
+        proxy_connections_processor: Rc<Mutex<dyn SignalingEventHandler>>,
+    ) -> Result<SignalingController, AppError> {
+        Ok(SignalingController {
+            event_channel_sender,
+            event_processors: HashMap::from([(
+                EventType::ProxyConnections,
+                proxy_connections_processor,
+            )]),
+            message_inbox: Arc::new(Mutex::new(HashMap::from([(
+                EventType::ProxyConnections,
+                VecDeque::new(),
+            )]))),
+            event_loop_processing: Arc::new(Mutex::new(false)),
+        })
+    }
+
+    // tests
+    // =====
+
+    #[test]
+    fn sigcontrol_new() {
+        let _ = SignalingController::new(
+            Arc::new(Mutex::new(MockSvcMgr::new())),
+            mpsc::channel().0,
+            create_user(),
+            Arc::new(Mutex::new(VecDeque::new())),
+        );
+    }
+
+    #[test]
+    fn sigcontrol_spawn_event_loop_when_inbox_has_message() {
+        let mut proxy_conns_processor = MockSigEvtHandler::new();
+        proxy_conns_processor
+            .expect_on_loop_cycle()
+            .with(predicate::always())
+            .return_once(|_| Ok(()));
+        let controller = create_controller(
+            mpsc::channel().0,
+            Rc::new(Mutex::new(proxy_conns_processor)),
+        )
+        .unwrap();
+
+        let event_loop_processing = controller.event_loop_processing.clone();
+        let message_inbox = controller.message_inbox.clone();
+        message_inbox
+            .lock()
+            .unwrap()
+            .get_mut(&EventType::ProxyConnections)
+            .unwrap()
+            .push_back(SignalEvent::new(
+                control::pdu::CODE_OK,
+                &None,
+                &EventType::ProxyConnections,
+                &Some(json!([])),
+            ));
+
+        let controller = Arc::new(Mutex::new(controller));
+
+        let result = SignalingController::spawn_event_loop(
+            &controller.clone(),
+            Some(Duration::from_millis(500)),
+        );
+
+        if let Err(err) = result {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+
+        thread::sleep(Duration::from_millis(250));
+
+        if !*event_loop_processing.lock().unwrap() {
+            panic!("Event loop processing state not active");
+        }
+
+        *event_loop_processing.lock().unwrap() = false;
+
+        assert!(message_inbox
+            .lock()
+            .unwrap()
+            .get(&EventType::ProxyConnections)
+            .is_some());
+        assert!(message_inbox
+            .lock()
+            .unwrap()
+            .get(&EventType::ProxyConnections)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn sigcontrol_spawn_event_loop_when_inbox_no_message() {
+        let mut proxy_conns_processor = MockSigEvtHandler::new();
+        proxy_conns_processor
+            .expect_on_loop_cycle()
+            .with(predicate::always())
+            .return_once(|_| Ok(()));
+        let controller = create_controller(
+            mpsc::channel().0,
+            Rc::new(Mutex::new(proxy_conns_processor)),
+        )
+        .unwrap();
+
+        let event_loop_processing = controller.event_loop_processing.clone();
+        let message_inbox = controller.message_inbox.clone();
+
+        let controller = Arc::new(Mutex::new(controller));
+
+        let result = SignalingController::spawn_event_loop(
+            &controller.clone(),
+            Some(Duration::from_millis(500)),
+        );
+
+        if let Err(err) = result {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+
+        thread::sleep(Duration::from_millis(250));
+
+        if !*event_loop_processing.lock().unwrap() {
+            panic!("Event loop processing state not active");
+        }
+
+        *event_loop_processing.lock().unwrap() = false;
+
+        assert!(message_inbox
+            .lock()
+            .unwrap()
+            .get(&EventType::ProxyConnections)
+            .is_some());
+        assert!(message_inbox
+            .lock()
+            .unwrap()
+            .get(&EventType::ProxyConnections)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn sigcontrol_spawn_event_loop_when_inbox_no_message_and_process_err() {
+        let mut proxy_conns_processor = MockSigEvtHandler::new();
+        proxy_conns_processor
+            .expect_on_loop_cycle()
+            .with(predicate::always())
+            .return_once(|_| Err(AppError::General("process error".to_string())));
+        let event_channel = mpsc::channel();
+        let controller =
+            create_controller(event_channel.0, Rc::new(Mutex::new(proxy_conns_processor))).unwrap();
+
+        let event_loop_processing = controller.event_loop_processing.clone();
+        let message_inbox = controller.message_inbox.clone();
+
+        let controller = Arc::new(Mutex::new(controller));
+
+        let result = SignalingController::spawn_event_loop(
+            &controller.clone(),
+            Some(Duration::from_millis(500)),
+        );
+
+        if let Err(err) = result {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+
+        thread::sleep(Duration::from_millis(250));
+
+        match event_channel.1.try_recv() {
+            Ok(event) => {
+                if let conn_std::ConnectionEvent::Closing = event {
+                } else {
+                    panic!("Unexpected conn event recvd: evt={:?}", event)
+                }
+            }
+            Err(err) => {
+                panic!("Unexpected conn event channel result: err={:?}", &err);
+            }
+        }
+
+        if *event_loop_processing.lock().unwrap() {
+            *event_loop_processing.lock().unwrap() = false;
+            panic!("Event loop processing state not disabled");
+        }
+
+        assert!(message_inbox
+            .lock()
+            .unwrap()
+            .get(&EventType::ProxyConnections)
+            .is_some());
+        assert!(message_inbox
+            .lock()
+            .unwrap()
+            .get(&EventType::ProxyConnections)
+            .unwrap()
+            .is_empty());
+    }
+
+    #[test]
+    fn sigcontrol_process_inbound_message_when_wrong_control_channel() {
+        let mut controller = create_controller(
+            mpsc::channel().0,
+            Rc::new(Mutex::new(MockSigEvtHandler::new())),
+        )
+        .unwrap();
+
+        let msg_frame = MessageFrame::new(
+            ControlChannel::Management,
+            control::pdu::CODE_OK,
+            &Some("msg1".to_string()),
+            &None,
+            &Some(json!([])),
+        );
+
+        let result = controller.process_inbound_message(msg_frame);
+
+        if let Ok(()) = result {
+            panic!("Unexpected successful result");
+        }
+    }
+
+    #[test]
+    fn sigcontrol_process_inbound_message_when_event_type_is_general() {
+        let mut controller = create_controller(
+            mpsc::channel().0,
+            Rc::new(Mutex::new(MockSigEvtHandler::new())),
+        )
+        .unwrap();
+
+        let msg_frame = MessageFrame::new(
+            ControlChannel::Signaling,
+            control::pdu::CODE_OK,
+            &None,
+            &Some(json!(EventType::General)),
+            &Some(json!([])),
+        );
+
+        let result = controller.process_inbound_message(msg_frame);
+
+        if let Err(err) = result {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+    }
+
+    #[test]
+    fn sigcontrol_process_inbound_message_when_event_type_is_proxy_conns() {
+        let mut controller = create_controller(
+            mpsc::channel().0,
+            Rc::new(Mutex::new(MockSigEvtHandler::new())),
+        )
+        .unwrap();
+
+        let msg_frame = MessageFrame::new(
+            ControlChannel::Signaling,
+            control::pdu::CODE_OK,
+            &None,
+            &Some(json!(EventType::ProxyConnections)),
+            &Some(json!([])),
+        );
+
+        assert!(controller
+            .message_inbox
+            .lock()
+            .unwrap()
+            .get(&EventType::ProxyConnections)
+            .is_some());
+        assert!(controller
+            .message_inbox
+            .lock()
+            .unwrap()
+            .get(&EventType::ProxyConnections)
+            .unwrap()
+            .is_empty());
+
+        let result = controller.process_inbound_message(msg_frame);
+
+        if let Err(err) = result {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+
+        assert_eq!(
+            controller
+                .message_inbox
+                .lock()
+                .unwrap()
+                .get(&EventType::ProxyConnections)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert_eq!(
+            *controller
+                .message_inbox
+                .lock()
+                .unwrap()
+                .get(&EventType::ProxyConnections)
+                .unwrap()
+                .get(0)
+                .unwrap(),
+            SignalEvent::new(
+                control::pdu::CODE_OK,
+                &None,
+                &EventType::ProxyConnections,
+                &Some(json!([])),
+            )
+        );
+    }
+
+    #[test]
+    fn sigcontrol_is_authenticated() {
+        let controller = create_controller(
+            mpsc::channel().0,
+            Rc::new(Mutex::new(MockSigEvtHandler::new())),
+        )
+        .unwrap();
+
+        assert!(controller.is_authenticated().is_none());
+    }
+}

--- a/crates/gateway/src/client/controller/signaling/proxy_connections.rs
+++ b/crates/gateway/src/client/controller/signaling/proxy_connections.rs
@@ -1,0 +1,561 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use serde_json::Value;
+use serde_json::Value::Array;
+
+use crate::client::controller::signaling::SignalingEventHandler;
+use crate::service::manager::ServiceMgr;
+use crate::service::proxy::proxy_base::ProxyAddrs;
+use trust0_common::control::signaling::event::{EventType, ProxyConnection, SignalEvent};
+use trust0_common::error::AppError;
+use trust0_common::error::AppError::General;
+use trust0_common::logging::{error, warn};
+use trust0_common::{control, model, target};
+
+const LIVENESS_MAX_CONSECUTIVE_MISSING_CONNECTION_PROBES: u16 = 5;
+const LIVENESS_MAX_CONSECUTIVE_MISSING_SIGNAL_PROBES: u16 = 5;
+
+/// Process inbound proxy connections signaling message events
+pub struct ProxyConnectionsProcessor {
+    /// Service manager
+    service_mgr: Arc<Mutex<dyn ServiceMgr>>,
+    /// User model object
+    user: model::user::User,
+    /// Queued PDU responses to be sent to client
+    message_outbox: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    /// Missing connection bind addresses
+    /// key: (client bind address, gateway bind address)
+    /// value: (missing count, service ID, proxy key)
+    missing_connection_binds: HashMap<ProxyAddrs, (u16, u64, String)>,
+    /// Missing signal event probes
+    missing_signal_probes: u16,
+}
+
+impl ProxyConnectionsProcessor {
+    /// ProxyConnectionsProcessor constructor
+    ///
+    /// # Arguments
+    ///
+    /// * `service_mgr` - Service manager
+    /// * `user` - User model object
+    /// * `message_outbox` - Queued PDU responses to be sent to client
+    ///
+    /// # Returns
+    ///
+    /// A newly constructed [`ProxyConnectionsProcessor`] object.
+    ///
+    pub fn new(
+        service_mgr: Arc<Mutex<dyn ServiceMgr>>,
+        user: model::user::User,
+        message_outbox: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    ) -> Self {
+        Self {
+            service_mgr,
+            user,
+            message_outbox,
+            missing_connection_binds: HashMap::new(),
+            missing_signal_probes: 0,
+        }
+    }
+
+    /// Gather proxy keys/addresses for user's service proxy connections.
+    ///
+    /// # Returns
+    ///
+    /// A map of (`service ID`, (`service name`, Vec<(`proxy key`, `proxy addrs`)>)) corresponding to user's connections.
+    ///
+    fn current_user_proxy_keys(&self) -> HashMap<u64, (String, Vec<(String, ProxyAddrs)>)> {
+        let service_proxies = self.service_mgr.lock().unwrap().get_service_proxies();
+        service_proxies
+            .iter()
+            .map(|service_proxy| {
+                let service_proxy = service_proxy.lock().unwrap();
+                let service = &service_proxy.get_service();
+                (
+                    service.service_id,
+                    (
+                        service.name.clone(),
+                        service_proxy
+                            .get_proxy_keys_for_user(self.user.user_id)
+                            .clone(),
+                    ),
+                )
+            })
+            .collect::<HashMap<u64, (String, Vec<(String, ProxyAddrs)>)>>()
+    }
+
+    /// Process inbound proxy connections signal event
+    ///
+    /// # Arguments
+    ///
+    /// * `service_mgr` - Service manager
+    /// * `proxy_keys` - Current proxy keys and address binds for user
+    /// * `signal_event` - Proxy connections signal event
+    ///
+    /// # Returns
+    ///
+    /// A [`Result`] indicating success/failure of the processing operation.
+    ///
+    #[allow(clippy::type_complexity)]
+    fn process_inbound_event(
+        &mut self,
+        service_mgr: &Arc<Mutex<dyn ServiceMgr>>,
+        proxy_keys: &HashMap<u64, (String, Vec<(String, ProxyAddrs)>)>,
+        signal_event: SignalEvent,
+    ) -> Result<(), AppError> {
+        let mut proxy_context_map = HashMap::new();
+        let mut missing_conn_binds = HashMap::new();
+        let mut shutdown_conn_binds = Vec::new();
+
+        // Set up client/gateway connection address sets
+        let client_conn_addrs: HashSet<ProxyAddrs> = match signal_event.data {
+            None => HashSet::new(),
+            Some(data) => HashSet::from_iter(
+                ProxyConnection::from_serde_value(&data)?
+                    .iter()
+                    .flat_map(|proxy_conn| proxy_conn.binds.clone())
+                    .map(|proxy_addrs| {
+                        (
+                            #[allow(clippy::get_first)]
+                            proxy_addrs.get(0).as_ref().unwrap().to_string(),
+                            proxy_addrs.get(1).as_ref().unwrap().to_string(),
+                        )
+                    })
+                    .collect::<HashSet<ProxyAddrs>>(),
+            ),
+        };
+
+        let mut gateway_conn_addrs: HashSet<ProxyAddrs> = HashSet::new();
+        for (service_id, (_, service_proxy_keys)) in proxy_keys {
+            for service_proxy_key in service_proxy_keys {
+                proxy_context_map.insert(
+                    service_proxy_key.1.clone(),
+                    (service_id, service_proxy_key.0.clone()),
+                );
+                gateway_conn_addrs.insert(service_proxy_key.1.clone());
+            }
+        }
+
+        // Determine missing connections from client set
+        for missing_conn_bind in gateway_conn_addrs.difference(&client_conn_addrs) {
+            match self.missing_connection_binds.get(missing_conn_bind) {
+                None => {
+                    let (service_id, proxy_key) =
+                        proxy_context_map.get(missing_conn_bind).unwrap().clone();
+                    missing_conn_binds.insert(
+                        missing_conn_bind.clone(),
+                        (1, *service_id, proxy_key.clone()),
+                    );
+                }
+                Some((count, service_id, proxy_key)) => {
+                    let missing_count = count + 1;
+                    if missing_count >= LIVENESS_MAX_CONSECUTIVE_MISSING_CONNECTION_PROBES {
+                        shutdown_conn_binds.push((
+                            *service_id,
+                            proxy_key.clone(),
+                            missing_conn_bind.clone(),
+                        ));
+                    } else {
+                        missing_conn_binds.insert(
+                            missing_conn_bind.clone(),
+                            (missing_count, *service_id, proxy_key.clone()),
+                        );
+                    }
+                }
+            }
+        }
+
+        self.missing_connection_binds = missing_conn_binds;
+
+        // Shutdown dead connections
+        let mut errors: Vec<String> = vec![];
+
+        for shutdown_conn_bind in &shutdown_conn_binds {
+            warn(
+                &target!(),
+                &format!(
+                    "Shutting down dead proxy connection: user_id={}, svc_id={}, proxy_addrs={:?}",
+                    &self.user.user_id, shutdown_conn_bind.0, shutdown_conn_bind.1
+                ),
+            );
+
+            if let Err(err) = service_mgr
+                .lock()
+                .unwrap()
+                .shutdown_connection(shutdown_conn_bind.0, &shutdown_conn_bind.1)
+            {
+                errors.push(format!("{:?}", &err));
+            }
+        }
+
+        if !errors.is_empty() {
+            Err(General(format!(
+                "Error shutting down connection(s): user_id={}, errs={}",
+                &self.user.user_id,
+                errors.join(", ")
+            )))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Process outbound proxy connections signal event
+    ///
+    /// # Arguments
+    ///
+    /// * `proxy_keys` - Current proxy keys and address binds for user
+    ///
+    /// # Returns
+    ///
+    /// A [`Result`] indicating success/failure of the processing operation.
+    ///
+    #[allow(clippy::type_complexity)]
+    fn process_outbound_event(
+        &mut self,
+        proxy_keys: &HashMap<u64, (String, Vec<(String, ProxyAddrs)>)>,
+    ) -> Result<(), AppError> {
+        let mut proxy_connections: Vec<Value> = Vec::new();
+
+        for (service_name, service_proxy_keys) in proxy_keys.values() {
+            proxy_connections.push(
+                ProxyConnection::new(
+                    service_name.as_str(),
+                    service_proxy_keys
+                        .iter()
+                        .map(|k| vec![k.1 .0.to_string(), k.1 .1.to_string()])
+                        .collect::<Vec<Vec<String>>>(),
+                )
+                .try_into()
+                .unwrap(),
+            );
+        }
+
+        self.message_outbox.lock().unwrap().push_back(
+            control::pdu::MessageFrame::new(
+                control::pdu::ControlChannel::Signaling,
+                control::pdu::CODE_OK,
+                &None,
+                &Some(serde_json::to_value(EventType::ProxyConnections).unwrap()),
+                &Some(Array(proxy_connections)),
+            )
+            .build_pdu()?,
+        );
+
+        Ok(())
+    }
+}
+
+unsafe impl Send for ProxyConnectionsProcessor {}
+
+impl SignalingEventHandler for ProxyConnectionsProcessor {
+    fn on_loop_cycle(&mut self, signal_events: VecDeque<SignalEvent>) -> Result<(), AppError> {
+        let proxy_keys = self.current_user_proxy_keys();
+        let service_mgr = self.service_mgr.clone();
+
+        // Process inbound message(s)
+        if !signal_events.is_empty() {
+            self.missing_signal_probes = 0;
+
+            for signal_event in signal_events {
+                if let Err(err) =
+                    self.process_inbound_event(&service_mgr, &proxy_keys, signal_event)
+                {
+                    error(&target!(), &format!("{:?}", &err));
+                }
+            }
+        }
+        // Process missing signal event
+        else {
+            self.missing_signal_probes += 1;
+            if self.missing_signal_probes >= LIVENESS_MAX_CONSECUTIVE_MISSING_SIGNAL_PROBES {
+                return Err(AppError::General(format!(
+                    "Client not responsive, closing all connections: user_id={}",
+                    &self.user.user_id
+                )));
+            }
+        }
+
+        // Process outbound message
+        self.process_outbound_event(&proxy_keys)
+    }
+}
+
+/// Unit tests
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::client::controller::tests::create_user;
+    use crate::service::manager::tests::MockSvcMgr;
+    use crate::service::proxy::proxy_base::tests::MockGwSvcProxyVisitor;
+    use mockall::predicate;
+    use serde_json::json;
+    use trust0_common::control::pdu;
+    use trust0_common::control::pdu::ControlChannel;
+
+    // utils
+    // =====
+
+    fn create_processor(
+        service_mgr: Arc<Mutex<dyn ServiceMgr>>,
+        message_outbox: Arc<Mutex<VecDeque<Vec<u8>>>>,
+    ) -> Result<ProxyConnectionsProcessor, AppError> {
+        Ok(ProxyConnectionsProcessor {
+            service_mgr,
+            user: create_user(),
+            message_outbox,
+            missing_connection_binds: HashMap::new(),
+            missing_signal_probes: 0,
+        })
+    }
+
+    // tests
+    // =====
+
+    #[test]
+    fn proxyconnproc_new() {
+        let processor = ProxyConnectionsProcessor::new(
+            Arc::new(Mutex::new(MockSvcMgr::new())),
+            create_user(),
+            Arc::new(Mutex::new(VecDeque::new())),
+        );
+
+        assert!(processor.missing_connection_binds.is_empty());
+        assert_eq!(processor.missing_signal_probes, 0);
+    }
+
+    #[test]
+    fn proxyconnproc_current_user_proxy_keys() {
+        let mut service_mgr = MockSvcMgr::new();
+        let mut service_proxy = MockGwSvcProxyVisitor::new();
+        service_proxy
+            .expect_get_service()
+            .times(1)
+            .return_once(|| model::service::Service {
+                service_id: 200,
+                name: "Service200".to_string(),
+                transport: model::service::Transport::TCP,
+                host: "localhost".to_string(),
+                port: 8200,
+            });
+        service_proxy
+            .expect_get_proxy_keys_for_user()
+            .with(predicate::eq(100))
+            .times(1)
+            .return_once(move |_| {
+                vec![(
+                    "key1".to_string(),
+                    ("addr1".to_string(), "addr2".to_string()),
+                )]
+            });
+        service_mgr
+            .expect_get_service_proxies()
+            .times(1)
+            .return_once(move || vec![Arc::new(Mutex::new(service_proxy))]);
+
+        let processor = create_processor(
+            Arc::new(Mutex::new(service_mgr)),
+            Arc::new(Mutex::new(VecDeque::new())),
+        );
+
+        let user_proxy_keys = processor.unwrap().current_user_proxy_keys();
+
+        assert!(user_proxy_keys.contains_key(&200));
+        assert_eq!(
+            *user_proxy_keys.get(&200).unwrap(),
+            (
+                "Service200".to_string(),
+                vec![(
+                    "key1".to_string(),
+                    ("addr1".to_string(), "addr2".to_string())
+                )]
+            )
+        );
+    }
+
+    #[test]
+    fn proxyconnproc_on_loop_cycle_when_1_found_and_1_missing_and_1_dead() {
+        let mut service_mgr = MockSvcMgr::new();
+        let mut service_proxy = MockGwSvcProxyVisitor::new();
+        service_proxy
+            .expect_get_service()
+            .times(1)
+            .return_once(|| model::service::Service {
+                service_id: 200,
+                name: "Service200".to_string(),
+                transport: model::service::Transport::TCP,
+                host: "localhost".to_string(),
+                port: 8200,
+            });
+        service_proxy
+            .expect_get_proxy_keys_for_user()
+            .with(predicate::eq(100))
+            .times(1)
+            .return_once(move |_| {
+                vec![
+                    (
+                        "key1".to_string(),
+                        ("addr1".to_string(), "addr2".to_string()),
+                    ),
+                    (
+                        "key2".to_string(),
+                        ("addr3".to_string(), "addr4".to_string()),
+                    ),
+                    (
+                        "key3".to_string(),
+                        ("addr5".to_string(), "addr6".to_string()),
+                    ),
+                ]
+            });
+        service_mgr
+            .expect_get_service_proxies()
+            .times(1)
+            .return_once(move || vec![Arc::new(Mutex::new(service_proxy))]);
+        service_mgr
+            .expect_shutdown_connection()
+            .with(predicate::eq(200), predicate::eq("key3".to_string()))
+            .times(1)
+            .return_once(|_, _| Ok(()));
+
+        let mut processor = create_processor(
+            Arc::new(Mutex::new(service_mgr)),
+            Arc::new(Mutex::new(VecDeque::new())),
+        )
+        .unwrap();
+        processor.missing_signal_probes = 1;
+        processor.missing_connection_binds.insert(
+            ("addr5".to_string(), "addr6".to_string()),
+            (
+                LIVENESS_MAX_CONSECUTIVE_MISSING_CONNECTION_PROBES - 1,
+                200,
+                "key3".to_string(),
+            ),
+        );
+
+        let result = processor.on_loop_cycle(VecDeque::from(vec![SignalEvent::new(
+            control::pdu::CODE_OK,
+            &None,
+            &EventType::ProxyConnections,
+            &Some(json!([
+                {
+                    "service_name": "Service200",
+                    "binds": [["addr1","addr2"]]
+                },
+            ])),
+        )]));
+
+        if let Err(err) = result {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+
+        assert_eq!(processor.missing_signal_probes, 0);
+        assert_eq!(processor.missing_connection_binds.len(), 1);
+        assert!(processor
+            .missing_connection_binds
+            .get(&("addr3".to_string(), "addr4".to_string()))
+            .is_some());
+        assert_eq!(
+            *processor
+                .missing_connection_binds
+                .get(&("addr3".to_string(), "addr4".to_string()))
+                .unwrap(),
+            (1, 200, "key2".to_string())
+        );
+        assert_eq!(processor.message_outbox.lock().unwrap().len(), 1);
+
+        let mut message = VecDeque::from(
+            processor
+                .message_outbox
+                .lock()
+                .unwrap()
+                .get(0)
+                .unwrap()
+                .clone(),
+        );
+        let message_result = pdu::MessageFrame::consume_next_pdu(&mut message);
+        assert!(message_result.is_ok());
+        let message_frame = message_result.unwrap();
+        assert!(message_frame.is_some());
+        assert_eq!(
+            message_frame.unwrap(),
+            pdu::MessageFrame::new(
+                ControlChannel::Signaling,
+                pdu::CODE_OK,
+                &None,
+                &Some(serde_json::to_value(EventType::ProxyConnections).unwrap()),
+                &Some(json!([
+                    {
+                        "service_name": "Service200",
+                        "binds": [
+                            ["addr1", "addr2"],
+                            ["addr3", "addr4"],
+                            ["addr5", "addr6"],
+                        ],
+                    },
+                ])),
+            ),
+        );
+    }
+
+    #[test]
+    fn proxyconnproc_on_loop_cycle_when_client_dead() {
+        let mut service_mgr = MockSvcMgr::new();
+        let mut service_proxy = MockGwSvcProxyVisitor::new();
+        service_proxy
+            .expect_get_service()
+            .times(1)
+            .return_once(|| model::service::Service {
+                service_id: 200,
+                name: "Service200".to_string(),
+                transport: model::service::Transport::TCP,
+                host: "localhost".to_string(),
+                port: 8200,
+            });
+        service_proxy
+            .expect_get_proxy_keys_for_user()
+            .with(predicate::eq(100))
+            .times(1)
+            .return_once(move |_| {
+                vec![
+                    (
+                        "key1".to_string(),
+                        ("addr1".to_string(), "addr2".to_string()),
+                    ),
+                    (
+                        "key2".to_string(),
+                        ("addr3".to_string(), "addr4".to_string()),
+                    ),
+                    (
+                        "key3".to_string(),
+                        ("addr5".to_string(), "addr6".to_string()),
+                    ),
+                ]
+            });
+        service_mgr
+            .expect_get_service_proxies()
+            .times(1)
+            .return_once(move || vec![Arc::new(Mutex::new(service_proxy))]);
+        service_mgr.expect_shutdown_connection().never();
+
+        let mut processor = create_processor(
+            Arc::new(Mutex::new(service_mgr)),
+            Arc::new(Mutex::new(VecDeque::new())),
+        )
+        .unwrap();
+        processor.missing_signal_probes = LIVENESS_MAX_CONSECUTIVE_MISSING_SIGNAL_PROBES - 1;
+
+        let result = processor.on_loop_cycle(VecDeque::new());
+
+        if let Ok(()) = result {
+            panic!("Unexpected successful result");
+        }
+
+        assert_eq!(
+            processor.missing_signal_probes,
+            LIVENESS_MAX_CONSECUTIVE_MISSING_SIGNAL_PROBES
+        );
+        assert_eq!(processor.missing_connection_binds.len(), 0);
+        assert!(processor.message_outbox.lock().unwrap().is_empty());
+    }
+}

--- a/crates/gateway/src/service/proxy/udp_proxy.rs
+++ b/crates/gateway/src/service/proxy/udp_proxy.rs
@@ -73,7 +73,7 @@ pub struct UdpGatewayProxyServerVisitor {
     services_by_proxy_key: Arc<Mutex<HashMap<String, u64>>>,
     users_by_proxy_addrs: HashMap<ProxyAddrs, u64>,
     proxy_addrs_by_proxy_key: HashMap<String, ProxyAddrs>,
-    proxy_keys_by_user: HashMap<u64, Vec<String>>,
+    proxy_keys_by_user: HashMap<u64, Vec<(String, ProxyAddrs)>>,
 }
 
 impl UdpGatewayProxyServerVisitor {
@@ -105,6 +105,15 @@ impl UdpGatewayProxyServerVisitor {
     }
 
     /// Stringified tuple client and gateway connection addresses
+    ///
+    /// # Arguments
+    ///
+    /// * `tls_conn` - TLS server connection for proxy
+    ///
+    /// # Returns
+    ///
+    /// A [`ProxyAddrs`] object corresponding to connection socket address pair (peer, local).
+    ///
     fn create_proxy_addrs(tls_conn: &TlsServerConnection) -> ProxyAddrs {
         let peer_addr = match &tls_conn.sock.peer_addr() {
             Ok(addr) => format!("{:?}", addr),
@@ -301,10 +310,10 @@ impl server_std::ServerVisitor for UdpGatewayProxyServerVisitor {
             .insert(proxy_key.clone(), proxy_addrs.clone());
 
         if let Some(proxy_keys) = self.proxy_keys_by_user.get_mut(user_id) {
-            proxy_keys.push(proxy_key.clone());
+            proxy_keys.push((proxy_key.clone(), proxy_addrs.clone()));
         } else {
             self.proxy_keys_by_user
-                .insert(*user_id, vec![proxy_key.clone()]);
+                .insert(*user_id, vec![(proxy_key.clone(), proxy_addrs.clone())]);
         }
 
         Ok(())
@@ -324,27 +333,21 @@ impl GatewayServiceProxyVisitor for UdpGatewayProxyServerVisitor {
         self.proxy_port
     }
 
-    fn get_proxy_addrs_for_user(&self, user_id: u64) -> Vec<ProxyAddrs> {
-        self.users_by_proxy_addrs
-            .iter()
-            .filter_map(|(proxy_addrs, uid)| {
-                if user_id == *uid {
-                    Some(proxy_addrs.clone())
-                } else {
-                    None
-                }
-            })
-            .collect()
+    fn get_proxy_keys_for_user(&self, user_id: u64) -> Vec<(String, ProxyAddrs)> {
+        self.proxy_keys_by_user
+            .get(&user_id)
+            .unwrap_or(&vec![])
+            .to_vec()
     }
 
     fn shutdown_connections(
         &mut self,
-        proxy_tasks_sender: Sender<ProxyExecutorEvent>,
+        proxy_tasks_sender: &Sender<ProxyExecutorEvent>,
         user_id: Option<u64>,
     ) -> Result<(), AppError> {
         let mut errors: Vec<String> = vec![];
 
-        let proxy_keys_lists: Vec<Vec<String>> = self
+        let proxy_keys_lists: Vec<Vec<(String, ProxyAddrs)>> = self
             .proxy_keys_by_user
             .iter()
             .filter(|(uid, _)| user_id.is_none() || (**uid == user_id.unwrap()))
@@ -355,11 +358,11 @@ impl GatewayServiceProxyVisitor for UdpGatewayProxyServerVisitor {
         for proxy_keys in proxy_keys_lists {
             for proxy_key in proxy_keys {
                 if let Err(err) =
-                    proxy_tasks_sender.send(ProxyExecutorEvent::Close(proxy_key.clone()))
+                    proxy_tasks_sender.send(ProxyExecutorEvent::Close(proxy_key.0.clone()))
                 {
-                    errors.push(format!("Error while sending request to close a UDP proxy connection: proxy_stream={}, err={:?}", &proxy_key, err));
+                    errors.push(format!("Error while sending request to close a UDP proxy connection: proxy_stream={}, err={:?}", &proxy_key.0, err));
                 } else {
-                    self.remove_proxy_for_key(&proxy_key);
+                    self.remove_proxy_for_key(&proxy_key.0);
                 }
             }
 
@@ -374,13 +377,31 @@ impl GatewayServiceProxyVisitor for UdpGatewayProxyServerVisitor {
         Ok(())
     }
 
+    fn shutdown_connection(
+        &mut self,
+        proxy_tasks_sender: &Sender<ProxyExecutorEvent>,
+        proxy_key: &str,
+    ) -> Result<(), AppError> {
+        if let Err(err) = proxy_tasks_sender.send(ProxyExecutorEvent::Close(proxy_key.to_string()))
+        {
+            Err(AppError::General(
+            format!("Error while sending request to close a UDP proxy connection: proxy_stream={}, err={:?}", &proxy_key, &err)))
+        } else {
+            self.remove_proxy_for_key(proxy_key);
+            Ok(())
+        }
+    }
+
     fn remove_proxy_for_key(&mut self, proxy_key: &str) -> bool {
         match self.proxy_addrs_by_proxy_key.get(proxy_key) {
             Some(proxy_addrs) => {
                 let proxy_addrs = proxy_addrs.clone();
                 let user_id = self.users_by_proxy_addrs.get(&proxy_addrs).unwrap();
                 if let Some(proxy_keys) = self.proxy_keys_by_user.get_mut(user_id) {
-                    proxy_keys.retain(|key| !key.eq(proxy_key))
+                    proxy_keys.retain(|key| !key.0.eq(proxy_key));
+                    if proxy_keys.is_empty() {
+                        self.proxy_keys_by_user.remove(user_id);
+                    }
                 }
                 self.proxy_addrs_by_proxy_key.remove(proxy_key);
                 self.users_by_proxy_addrs.remove(&proxy_addrs);
@@ -773,7 +794,28 @@ pub mod tests {
                 (("addr7".to_string(), "addr8".to_string()), 101),
             ]),
             proxy_addrs_by_proxy_key: HashMap::new(),
-            proxy_keys_by_user: HashMap::new(),
+            proxy_keys_by_user: HashMap::from([
+                (
+                    100,
+                    vec![
+                        (
+                            "key1".to_string(),
+                            ("addr1".to_string(), "addr2".to_string()),
+                        ),
+                        (
+                            "key2".to_string(),
+                            ("addr5".to_string(), "addr6".to_string()),
+                        ),
+                    ],
+                ),
+                (
+                    101,
+                    vec![(
+                        "key3".to_string(),
+                        ("addr3".to_string(), "addr4".to_string()),
+                    )],
+                ),
+            ]),
         };
 
         assert_eq!(server_visitor.get_service(), service);
@@ -781,13 +823,19 @@ pub mod tests {
         assert_eq!(server_visitor.get_proxy_host().unwrap(), "gwhost1");
         assert_eq!(server_visitor.get_proxy_port(), 2000);
 
-        let expected_proxy_addrs = vec![
-            ("addr1".to_string(), "addr2".to_string()),
-            ("addr5".to_string(), "addr6".to_string()),
+        let expected_proxy_keys = vec![
+            (
+                "key1".to_string(),
+                ("addr1".to_string(), "addr2".to_string()),
+            ),
+            (
+                "key2".to_string(),
+                ("addr5".to_string(), "addr6".to_string()),
+            ),
         ];
-        let mut proxy_addrs = server_visitor.get_proxy_addrs_for_user(100);
-        proxy_addrs.sort();
-        assert_eq!(proxy_addrs, expected_proxy_addrs);
+        let mut proxy_keys = server_visitor.get_proxy_keys_for_user(100);
+        proxy_keys.sort();
+        assert_eq!(proxy_keys, expected_proxy_keys);
     }
 
     #[test]
@@ -818,9 +866,9 @@ pub mod tests {
             proxy_tasks_sender: proxy_tasks_sender.clone(),
             proxy_events_sender: sync::mpsc::channel().0,
             services_by_proxy_key: Arc::new(Mutex::new(HashMap::from([
-                ("key1".to_string(), 100),
-                ("key2".to_string(), 100),
-                ("key3".to_string(), 101),
+                ("key1".to_string(), 200),
+                ("key2".to_string(), 200),
+                ("key3".to_string(), 201),
             ]))),
             users_by_proxy_addrs: HashMap::from([
                 (("addr1".to_string(), "addr2".to_string()), 100),
@@ -842,12 +890,30 @@ pub mod tests {
                 ),
             ]),
             proxy_keys_by_user: HashMap::from([
-                (100, vec!["key1".to_string(), "key2".to_string()]),
-                (101, vec!["key3".to_string()]),
+                (
+                    100,
+                    vec![
+                        (
+                            "key1".to_string(),
+                            ("addr1".to_string(), "addr2".to_string()),
+                        ),
+                        (
+                            "key2".to_string(),
+                            ("addr3".to_string(), "addr4".to_string()),
+                        ),
+                    ],
+                ),
+                (
+                    101,
+                    vec![(
+                        "key3".to_string(),
+                        ("addr5".to_string(), "addr6".to_string()),
+                    )],
+                ),
             ]),
         };
 
-        if let Err(err) = server_visitor.shutdown_connections(proxy_tasks_sender, None) {
+        if let Err(err) = server_visitor.shutdown_connections(&proxy_tasks_sender, None) {
             panic!("Unexpected result: err={:?}", &err);
         }
 
@@ -876,6 +942,7 @@ pub mod tests {
 
         assert!(server_visitor.proxy_addrs_by_proxy_key.is_empty());
         assert!(server_visitor.users_by_proxy_addrs.is_empty());
+        assert!(server_visitor.proxy_keys_by_user.is_empty());
         assert!(server_visitor
             .services_by_proxy_key
             .lock()
@@ -911,9 +978,9 @@ pub mod tests {
             proxy_tasks_sender: proxy_tasks_sender.clone(),
             proxy_events_sender: sync::mpsc::channel().0,
             services_by_proxy_key: Arc::new(Mutex::new(HashMap::from([
-                ("key1".to_string(), 100),
-                ("key2".to_string(), 100),
-                ("key3".to_string(), 101),
+                ("key1".to_string(), 200),
+                ("key2".to_string(), 200),
+                ("key3".to_string(), 201),
             ]))),
             users_by_proxy_addrs: HashMap::from([
                 (("addr1".to_string(), "addr2".to_string()), 100),
@@ -935,12 +1002,30 @@ pub mod tests {
                 ),
             ]),
             proxy_keys_by_user: HashMap::from([
-                (100, vec!["key1".to_string(), "key2".to_string()]),
-                (101, vec!["key3".to_string()]),
+                (
+                    100,
+                    vec![
+                        (
+                            "key1".to_string(),
+                            ("addr1".to_string(), "addr2".to_string()),
+                        ),
+                        (
+                            "key2".to_string(),
+                            ("addr3".to_string(), "addr4".to_string()),
+                        ),
+                    ],
+                ),
+                (
+                    101,
+                    vec![(
+                        "key3".to_string(),
+                        ("addr5".to_string(), "addr6".to_string()),
+                    )],
+                ),
             ]),
         };
 
-        if let Err(err) = server_visitor.shutdown_connections(proxy_tasks_sender, Some(100)) {
+        if let Err(err) = server_visitor.shutdown_connections(&proxy_tasks_sender, Some(100)) {
             panic!("Unexpected result: err={:?}", &err);
         }
 
@@ -977,6 +1062,14 @@ pub mod tests {
                 .get(&("addr5".to_string(), "addr6".to_string())),
             Some(&101)
         );
+        assert_eq!(server_visitor.proxy_keys_by_user.len(), 1);
+        assert_eq!(
+            server_visitor.proxy_keys_by_user.get(&101),
+            Some(&vec![(
+                "key3".to_string(),
+                ("addr5".to_string(), "addr6".to_string())
+            )])
+        );
         assert_eq!(
             server_visitor.services_by_proxy_key.lock().unwrap().len(),
             1
@@ -987,7 +1080,270 @@ pub mod tests {
                 .lock()
                 .unwrap()
                 .get("key3"),
-            Some(&101)
+            Some(&201)
+        );
+    }
+
+    #[test]
+    fn udpsvrproxyvisit_shutdown_connection_when_proxy_key_known() {
+        let app_config = Arc::new(
+            config::tests::create_app_config_with_repos(
+                Arc::new(Mutex::new(MockUserRepo::new())),
+                Arc::new(Mutex::new(MockServiceRepo::new())),
+                Arc::new(Mutex::new(MockRoleRepo::new())),
+                Arc::new(Mutex::new(MockAccessRepo::new())),
+            )
+            .unwrap(),
+        );
+        let (proxy_tasks_sender, proxy_tasks_receiver) = sync::mpsc::channel();
+
+        let mut server_visitor = UdpGatewayProxyServerVisitor {
+            app_config: app_config.clone(),
+            service_mgr: Arc::new(Mutex::new(MockSvcMgr::new())),
+            service: Service {
+                service_id: 200,
+                name: "svc200".to_string(),
+                transport: Transport::UDP,
+                host: "svchost1".to_string(),
+                port: 4000,
+            },
+            proxy_host: Some("gwhost1".to_string()),
+            proxy_port: 2000,
+            proxy_tasks_sender: proxy_tasks_sender.clone(),
+            proxy_events_sender: sync::mpsc::channel().0,
+            services_by_proxy_key: Arc::new(Mutex::new(HashMap::from([
+                ("key1".to_string(), 200),
+                ("key2".to_string(), 200),
+                ("key3".to_string(), 201),
+            ]))),
+            users_by_proxy_addrs: HashMap::from([
+                (("addr1".to_string(), "addr2".to_string()), 100),
+                (("addr3".to_string(), "addr4".to_string()), 100),
+                (("addr5".to_string(), "addr6".to_string()), 101),
+            ]),
+            proxy_addrs_by_proxy_key: HashMap::from([
+                (
+                    "key1".to_string(),
+                    ("addr1".to_string(), "addr2".to_string()),
+                ),
+                (
+                    "key2".to_string(),
+                    ("addr3".to_string(), "addr4".to_string()),
+                ),
+                (
+                    "key3".to_string(),
+                    ("addr5".to_string(), "addr6".to_string()),
+                ),
+            ]),
+            proxy_keys_by_user: HashMap::from([
+                (
+                    100,
+                    vec![
+                        (
+                            "key1".to_string(),
+                            ("addr1".to_string(), "addr2".to_string()),
+                        ),
+                        (
+                            "key2".to_string(),
+                            ("addr3".to_string(), "addr4".to_string()),
+                        ),
+                    ],
+                ),
+                (
+                    101,
+                    vec![(
+                        "key3".to_string(),
+                        ("addr5".to_string(), "addr6".to_string()),
+                    )],
+                ),
+            ]),
+        };
+
+        if let Err(err) = server_visitor.shutdown_connection(&proxy_tasks_sender, "key3") {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+
+        match proxy_tasks_receiver.try_recv() {
+            Ok(proxy_task) => match proxy_task {
+                ProxyExecutorEvent::Close(key) => assert_eq!(key, "key3"),
+                ProxyExecutorEvent::OpenTcpAndTcpProxy(key, _) => panic!(
+                    "Unexpected received open tcp&tcp proxy task: key={:?}",
+                    &key
+                ),
+                ProxyExecutorEvent::OpenChannelAndTcpProxy(key, _) => panic!(
+                    "Unexpected received open channel&tcp proxy task: key={:?}",
+                    &key
+                ),
+                ProxyExecutorEvent::OpenTcpAndUdpProxy(key, _) => panic!(
+                    "Unexpected received open tcp&udp proxy task: key={:?}",
+                    &key
+                ),
+            },
+            Err(err) => panic!("Unexpected received proxy task error: err={:?}", &err),
+        }
+
+        assert_eq!(server_visitor.proxy_addrs_by_proxy_key.len(), 2);
+        assert_eq!(
+            server_visitor.proxy_addrs_by_proxy_key.get("key1"),
+            Some(&("addr1".to_string(), "addr2".to_string()))
+        );
+        assert_eq!(
+            server_visitor.proxy_addrs_by_proxy_key.get("key2"),
+            Some(&("addr3".to_string(), "addr4".to_string()))
+        );
+        assert_eq!(server_visitor.users_by_proxy_addrs.len(), 2);
+        assert_eq!(
+            server_visitor
+                .users_by_proxy_addrs
+                .get(&("addr1".to_string(), "addr2".to_string())),
+            Some(&100)
+        );
+        assert_eq!(
+            server_visitor
+                .users_by_proxy_addrs
+                .get(&("addr3".to_string(), "addr4".to_string())),
+            Some(&100)
+        );
+        assert_eq!(server_visitor.proxy_keys_by_user.len(), 1);
+        assert_eq!(
+            server_visitor.proxy_keys_by_user.get(&100),
+            Some(&vec![
+                (
+                    "key1".to_string(),
+                    ("addr1".to_string(), "addr2".to_string())
+                ),
+                (
+                    "key2".to_string(),
+                    ("addr3".to_string(), "addr4".to_string())
+                )
+            ])
+        );
+        assert_eq!(
+            server_visitor.services_by_proxy_key.lock().unwrap().len(),
+            2
+        );
+        assert_eq!(
+            server_visitor
+                .services_by_proxy_key
+                .lock()
+                .unwrap()
+                .get("key1"),
+            Some(&200)
+        );
+        assert_eq!(
+            server_visitor
+                .services_by_proxy_key
+                .lock()
+                .unwrap()
+                .get("key2"),
+            Some(&200)
+        );
+    }
+
+    #[test]
+    fn udpsvrproxyvisit_shutdown_connection_when_proxy_key_unknown() {
+        let app_config = Arc::new(
+            config::tests::create_app_config_with_repos(
+                Arc::new(Mutex::new(MockUserRepo::new())),
+                Arc::new(Mutex::new(MockServiceRepo::new())),
+                Arc::new(Mutex::new(MockRoleRepo::new())),
+                Arc::new(Mutex::new(MockAccessRepo::new())),
+            )
+            .unwrap(),
+        );
+        let (proxy_tasks_sender, proxy_tasks_receiver) = sync::mpsc::channel();
+
+        let mut server_visitor = UdpGatewayProxyServerVisitor {
+            app_config: app_config.clone(),
+            service_mgr: Arc::new(Mutex::new(MockSvcMgr::new())),
+            service: Service {
+                service_id: 200,
+                name: "svc200".to_string(),
+                transport: Transport::UDP,
+                host: "svchost1".to_string(),
+                port: 4000,
+            },
+            proxy_host: Some("gwhost1".to_string()),
+            proxy_port: 2000,
+            proxy_tasks_sender: proxy_tasks_sender.clone(),
+            proxy_events_sender: sync::mpsc::channel().0,
+            services_by_proxy_key: Arc::new(Mutex::new(HashMap::from([
+                ("key1".to_string(), 200),
+                ("key2".to_string(), 200),
+                ("key3".to_string(), 201),
+            ]))),
+            users_by_proxy_addrs: HashMap::from([
+                (("addr1".to_string(), "addr2".to_string()), 100),
+                (("addr3".to_string(), "addr4".to_string()), 100),
+                (("addr5".to_string(), "addr6".to_string()), 101),
+            ]),
+            proxy_addrs_by_proxy_key: HashMap::from([
+                (
+                    "key1".to_string(),
+                    ("addr1".to_string(), "addr2".to_string()),
+                ),
+                (
+                    "key2".to_string(),
+                    ("addr3".to_string(), "addr4".to_string()),
+                ),
+                (
+                    "key3".to_string(),
+                    ("addr5".to_string(), "addr6".to_string()),
+                ),
+            ]),
+            proxy_keys_by_user: HashMap::from([
+                (
+                    100,
+                    vec![
+                        (
+                            "key1".to_string(),
+                            ("addr1".to_string(), "addr2".to_string()),
+                        ),
+                        (
+                            "key2".to_string(),
+                            ("addr3".to_string(), "addr4".to_string()),
+                        ),
+                    ],
+                ),
+                (
+                    101,
+                    vec![(
+                        "key3".to_string(),
+                        ("addr5".to_string(), "addr6".to_string()),
+                    )],
+                ),
+            ]),
+        };
+
+        if let Err(err) = server_visitor.shutdown_connection(&proxy_tasks_sender, "key4") {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+
+        match proxy_tasks_receiver.try_recv() {
+            Ok(proxy_task) => match proxy_task {
+                ProxyExecutorEvent::Close(key) => assert_eq!(key, "key4"),
+                ProxyExecutorEvent::OpenTcpAndTcpProxy(key, _) => panic!(
+                    "Unexpected received open tcp&tcp proxy task: key={:?}",
+                    &key
+                ),
+                ProxyExecutorEvent::OpenChannelAndTcpProxy(key, _) => panic!(
+                    "Unexpected received open channel&tcp proxy task: key={:?}",
+                    &key
+                ),
+                ProxyExecutorEvent::OpenTcpAndUdpProxy(key, _) => panic!(
+                    "Unexpected received open tcp&udp proxy task: key={:?}",
+                    &key
+                ),
+            },
+            Err(err) => panic!("Unexpected received proxy task error: err={:?}", &err),
+        }
+
+        assert_eq!(server_visitor.proxy_addrs_by_proxy_key.len(), 3);
+        assert_eq!(server_visitor.users_by_proxy_addrs.len(), 3);
+        assert_eq!(server_visitor.proxy_keys_by_user.len(), 2);
+        assert_eq!(
+            server_visitor.services_by_proxy_key.lock().unwrap().len(),
+            3
         );
     }
 }

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -6,6 +6,8 @@
     * [Network Diagram](#network-diagram)
     * [User Connections](#user-connections)
     * [Control Plane](#control-plane)
+      * [Management Channel](#management-channel)
+      * [Signaling Channel](#signaling-channel)
     * [Service Proxy](#service-proxy)
     * [Client Auth](#client-auth)
       * [mTLS Authentication](#mtls-authentication)
@@ -52,7 +54,16 @@ Note - A future Trust0 may accommodate gateway-to-gateway service proxy routing.
 
 ### Control Plane
 
-The Control Plane connection is required and the first connection made between the T0C and a T0G. A REPL shell will be opened and the user may enter various commands:
+The Control Plane connection is required and the first connection made between the T0C and a T0G.
+
+There are 2 Control Plane channels:
+
+* `Management` - User command shell to manage service proxy connections (among other commands)
+* `Signaling` - An out-of-band channel, the client and gateway use for communication (events, liveliness probing, data, .. )
+
+#### Management Channel
+
+A REPL shell will be opened and the user may enter various commands:
 
 | Command     | Description                                                               |
 |-------------|---------------------------------------------------------------------------|
@@ -69,9 +80,20 @@ The Control Plane connection is required and the first connection made between t
 
 In the REPL shell, issue `help <COMMAND>` to learn more about these commands.
 
+#### Signaling Channel
+
+A bidirectional channel will be established between the client and gateway to asynchronously send events to each other.
+
+Here is the current list of signaling events in use:
+
+| Event Type        | Direction        | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+|-------------------|------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Proxy Connections | `T0C` <--> `T0G` | <p>This event is sent bidirectionally every `6 secs`. It contains the current list of service<br>proxy connections' bind address pairs (as known by the sending entity) for the<br>respective user session.</p><p>Each side will keep track of missing binds as a consecutive count. When that reaches `5`,<br>those corresponding missing connection(s) will be shut down.</p><p>Additionally, each side will also keep track of consecutive missing `Proxy Connections`<br>signal events. when that reaches `5`, the entire user session(control plane, service<br>proxy connections) will be shut down.</p> |
+
+
 ### Service Proxy
 
-Of note, `start` is a key command which is used to open up new service proxies.
+Regarding the [Management Channel](#management-channel) REPL shell, `start` is a key command which is used to open up new service proxies.
 
 ```
 Trust0 SDP Platform v0.1.0-alpha (enter 'help' for commands)


### PR DESCRIPTION
### Summary

A signaling control plane communication channel was added:

* Bidirectional out-of-band/asynchronous communication between client/gateway
* Supports multiple event types
* Initial `Proxy Connections` event type added, which sends list of known proxy connection address binds
* `Proxy Connections` allows both client and gateway to determine liveliness of connections and be able to shutdown seemingly dead connections
* Additionally `Proxy Connections` can shut down the whole client session (control plane and proxies) if it doesn't receive this event type from the other side.
