### PR TITLE
Feat rust based crl creator 240210

### DIFF
--- a/crates/common/src/crypto/crl.rs
+++ b/crates/common/src/crypto/crl.rs
@@ -1,0 +1,953 @@
+use crate::crypto::ca;
+use crate::error::AppError;
+use crate::{crypto, file};
+use pki_types::CertificateRevocationListDer;
+use rcgen::{
+    CertificateRevocationList, CertificateRevocationListParams, CrlIssuingDistributionPoint,
+    KeyIdMethod, RevocationReason, RevokedCertParams, SerialNumber,
+};
+use std::ops::DerefMut;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+use time::OffsetDateTime;
+
+const VALIDATION_MSG_CERTIFICATE_SERIAL_NUMBER_REQUIRED: &str =
+    "Certificate Serial Number required";
+const VALIDATION_MSG_CERTIFICATE_REVOCATION_DATETIME_REQUIRED: &str =
+    "Certificate Revocation Datetime required";
+const VALIDATION_MSG_SERIAL_NUMBER_LIMIT_EXCEEDED: &str = "Serial Number may not exceed 20 octets";
+const VALIDATION_MSG_CRL_NUMBER_REQUIRED: &str = "CRL Number required";
+const VALIDATION_MSG_CRL_NUMBER_LIMIT_EXCEEDED: &str = "CRL Number may not exceed 20 octets";
+const VALIDATION_MSG_UPDATE_DATETIME_REQUIRED: &str = "Update Datetime required";
+const VALIDATION_MSG_NEXT_UPDATE_DATETIME_REQUIRED: &str = "Next Update Datetime required";
+const VALIDATION_MSG_SIGNATURE_ALGORITHM_REQUIRED: &str = "Signature Algorithm required";
+const VALIDATION_MSG_KEY_IDENTIFIER_METHOD_REQUIRED: &str = "Key Identifier Method required";
+
+/// Builder for a revoked certificate (to be added to a CRL)
+pub struct RevokedCertificateBuilder {
+    /// Unique for each certificate issued by a given CA
+    serial_number: Option<Vec<u8>>,
+    /// Datetime at which the CA processed the revocation.
+    revocation_datetime: Option<OffsetDateTime>,
+    /// (Optional) Reason for the certificate revocation
+    reason_code: Option<RevocationReason>,
+    /// (Optional) Datetime on which key was compromised or that the certificate otherwise became invalid
+    invalidity_datetime: Option<OffsetDateTime>,
+}
+
+impl RevokedCertificateBuilder {
+    /// Returns a new builder, which can create a [`RevokedCertParams`] object
+    ///
+    /// # Returns
+    ///
+    /// A [`RevokedCertificateBuilder`] object.
+    ///
+    pub fn new() -> Self {
+        Self {
+            serial_number: None,
+            revocation_datetime: None,
+            reason_code: None,
+            invalidity_datetime: None,
+        }
+    }
+
+    /// Sets the serial number
+    ///
+    /// # Arguments
+    ///
+    /// * `serial_number` - Serial number (to uniquely identify certificate, up to 20 octets)
+    ///
+    /// # Returns
+    ///
+    /// [`Self`] for further function invocation.
+    ///
+    pub fn serial_number(&mut self, serial_number: &[u8]) -> &mut Self {
+        self.serial_number = Some(serial_number.to_vec());
+        self
+    }
+
+    /// Sets the revocation datetime
+    ///
+    /// # Arguments
+    ///
+    /// * `revocation_datetime` - Datetime at which the CA processed the revocation
+    ///
+    /// # Returns
+    ///
+    /// [`Self`] for further function invocation.
+    ///
+    pub fn revocation_datetime(&mut self, revocation_datetime: &OffsetDateTime) -> &mut Self {
+        self.revocation_datetime = Some(*revocation_datetime);
+        self
+    }
+
+    /// Sets the revocation reason code
+    ///
+    /// # Arguments
+    ///
+    /// * `reason_code` - Reason for the certificate revocation
+    ///
+    /// # Returns
+    ///
+    /// [`Self`] for further function invocation.
+    ///
+    pub fn reason_code(&mut self, reason_code: &RevocationReason) -> &mut Self {
+        self.reason_code = Some(*reason_code);
+        self
+    }
+
+    /// Sets the invalidity datetime
+    ///
+    /// # Arguments
+    ///
+    /// * `invalidity_datetime` - Datetime on which key was compromised or that the certificate otherwise became invalid
+    ///
+    /// # Returns
+    ///
+    /// [`Self`] for further function invocation.
+    ///
+    pub fn invalidity_datetime(&mut self, invalidity_datetime: &OffsetDateTime) -> &mut Self {
+        self.invalidity_datetime = Some(*invalidity_datetime);
+        self
+    }
+
+    /// Invoke the build for the supplied data.
+    ///
+    /// # Returns
+    ///
+    /// A [`Result`] containing (if valid) a newly constructed [`RevokedCertParams`] object.
+    ///
+    pub fn build(&self) -> Result<RevokedCertParams, AppError> {
+        // Validation
+        let mut errors = Vec::new();
+
+        if self.serial_number.is_none() {
+            errors.push(VALIDATION_MSG_CERTIFICATE_SERIAL_NUMBER_REQUIRED.to_string());
+        } else if self.serial_number.as_ref().unwrap().len() > ca::SERIAL_NUMBER_MAX_OCTETS {
+            errors.push(VALIDATION_MSG_SERIAL_NUMBER_LIMIT_EXCEEDED.to_string());
+        }
+        if self.revocation_datetime.is_none() {
+            errors.push(VALIDATION_MSG_CERTIFICATE_REVOCATION_DATETIME_REQUIRED.to_string());
+        }
+        if self.serial_number.is_some()
+            && (self.serial_number.as_ref().unwrap().len() > ca::SERIAL_NUMBER_MAX_OCTETS)
+        {
+            errors.push(VALIDATION_MSG_SERIAL_NUMBER_LIMIT_EXCEEDED.to_string());
+        }
+
+        if !errors.is_empty() {
+            return Err(AppError::General(format!(
+                "Error building revoked certificate: errs={}",
+                errors.join(", ")
+            )));
+        }
+
+        // Valid, set up attributes
+
+        Ok(RevokedCertParams {
+            serial_number: SerialNumber::from_slice(
+                self.serial_number.as_ref().unwrap().as_slice(),
+            ),
+            revocation_time: *self.revocation_datetime.as_ref().unwrap(),
+            reason_code: self.reason_code,
+            invalidity_date: self.invalidity_datetime,
+        })
+    }
+}
+
+impl Default for RevokedCertificateBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Builder for a certificate revocation list (CRL)
+pub struct CertificateRevocationListBuilder {
+    /// CRL extension that conveys a monotonically increasing sequence number for a given CRL scope and CRL issuer
+    crl_number: Option<Vec<u8>>,
+    /// Issue datetime of this CRL
+    update_datetime: Option<OffsetDateTime>,
+    /// Datetime by which the next CRL will be issued
+    next_update_datetime: Option<OffsetDateTime>,
+    /// (Optional) CRL extension that identifies the CRL distribution point and scope for a particular CRL
+    issuing_distribution: Option<CrlIssuingDistributionPoint>,
+    /// Algorithm used by the CRL issuer to sign the certificate list
+    signature_algorithm: Option<ca::KeyAlgorithm>,
+    /// Means of identifying the public key corresponding to the private key used to sign a CRL
+    key_ident_method: Option<KeyIdMethod>,
+}
+
+impl CertificateRevocationListBuilder {
+    /// Returns a new builder, which can create a [`CertificateRevocationList`] object
+    ///
+    /// # Returns
+    ///
+    /// A [`CertificateRevocationListBuilder`] object.
+    ///
+    pub fn new() -> Self {
+        Self {
+            crl_number: None,
+            update_datetime: None,
+            next_update_datetime: None,
+            issuing_distribution: None,
+            signature_algorithm: None,
+            key_ident_method: None,
+        }
+    }
+
+    /// Sets the CRL number
+    ///
+    /// # Arguments
+    ///
+    /// * `crl_number` - CRL extension that conveys a monotonically increasing sequence number for a given CRL scope and CRL issuer
+    ///
+    /// # Returns
+    ///
+    /// [`Self`] for further function invocation.
+    ///
+    pub fn crl_number(&mut self, crl_number: &[u8]) -> &mut Self {
+        self.crl_number = Some(crl_number.to_vec());
+        self
+    }
+
+    /// Sets the CRL issue datetime
+    ///
+    /// # Arguments
+    ///
+    /// * `update_datetime` - Issue datetime of this CRL
+    ///
+    /// # Returns
+    ///
+    /// [`Self`] for further function invocation.
+    ///
+    pub fn update_datetime(&mut self, update_datetime: &OffsetDateTime) -> &mut Self {
+        self.update_datetime = Some(*update_datetime);
+        self
+    }
+
+    /// Sets the next CRL issue datetime
+    ///
+    /// # Arguments
+    ///
+    /// * `next_update_datetime` - Datetime by which the next CRL will be issued
+    ///
+    /// # Returns
+    ///
+    /// [`Self`] for further function invocation.
+    ///
+    pub fn next_update_datetime(&mut self, next_update_datetime: &OffsetDateTime) -> &mut Self {
+        self.next_update_datetime = Some(*next_update_datetime);
+        self
+    }
+
+    /// Sets the issuing distribution point
+    ///
+    /// # Arguments
+    ///
+    /// * `issuing_distribution` - CRL extension that identifies the CRL distribution point and scope for a particular CRL
+    ///
+    /// # Returns
+    ///
+    /// [`Self`] for further function invocation.
+    ///
+    pub fn issuing_distribution(
+        &mut self,
+        issuing_distribution: CrlIssuingDistributionPoint,
+    ) -> &mut Self {
+        self.issuing_distribution = Some(issuing_distribution);
+        self
+    }
+
+    /// Sets the signature algorithm
+    ///
+    /// # Arguments
+    ///
+    /// * `signature_algorithm` - Algorithm used by the CRL issuer to sign the certificate list
+    ///
+    /// # Returns
+    ///
+    /// [`Self`] for further function invocation.
+    ///
+    pub fn signature_algorithm(&mut self, signature_algorithm: &ca::KeyAlgorithm) -> &mut Self {
+        self.signature_algorithm = Some(signature_algorithm.clone());
+        self
+    }
+
+    /// Sets the key identifier method
+    ///
+    /// # Arguments
+    ///
+    /// * `key_ident_method` - Means of identifying the public key corresponding to the private key used to sign a CRL
+    ///
+    /// # Returns
+    ///
+    /// [`Self`] for further function invocation.
+    ///
+    pub fn key_ident_method(&mut self, key_ident_method: KeyIdMethod) -> &mut Self {
+        self.key_ident_method = Some(key_ident_method);
+        self
+    }
+
+    /// Invoke the build for the supplied data.
+    ///
+    /// # Arguments
+    ///
+    /// * `revoked_certificates` - List of revoked certificates (possibly empty)
+    ///
+    /// # Returns
+    ///
+    /// A [`Result`] containing a newly constructed [`CertificateRevocationList`] object.
+    ///
+    pub fn build(
+        &mut self,
+        revoked_certificates: Vec<RevokedCertParams>,
+    ) -> Result<CertificateRevocationList, AppError> {
+        // Validation
+        let mut errors = Vec::new();
+
+        if self.crl_number.is_none() {
+            errors.push(VALIDATION_MSG_CRL_NUMBER_REQUIRED.to_string());
+        } else if self.crl_number.as_ref().unwrap().len() > ca::SERIAL_NUMBER_MAX_OCTETS {
+            errors.push(VALIDATION_MSG_CRL_NUMBER_LIMIT_EXCEEDED.to_string());
+        }
+        if self.update_datetime.is_none() {
+            errors.push(VALIDATION_MSG_UPDATE_DATETIME_REQUIRED.to_string());
+        }
+        if self.next_update_datetime.is_none() {
+            errors.push(VALIDATION_MSG_NEXT_UPDATE_DATETIME_REQUIRED.to_string());
+        }
+        if self.signature_algorithm.is_none() {
+            errors.push(VALIDATION_MSG_SIGNATURE_ALGORITHM_REQUIRED.to_string());
+        }
+        if self.key_ident_method.is_none() {
+            errors.push(VALIDATION_MSG_KEY_IDENTIFIER_METHOD_REQUIRED.to_string());
+        }
+
+        if !errors.is_empty() {
+            return Err(AppError::General(format!(
+                "Error building certificate revocation list: errs={}",
+                errors.join(", ")
+            )));
+        }
+
+        // Valid, set up attributes
+
+        let crl_params = CertificateRevocationListParams {
+            this_update: self.update_datetime.unwrap(),
+            next_update: self.next_update_datetime.unwrap(),
+            crl_number: SerialNumber::from_slice(self.crl_number.as_ref().unwrap().as_slice()),
+            issuing_distribution_point: self.issuing_distribution.take(),
+            revoked_certs: revoked_certificates,
+            alg: self
+                .signature_algorithm
+                .as_ref()
+                .unwrap()
+                .signature_algorithm(),
+            key_identifier_method: self.key_ident_method.as_ref().unwrap().clone(),
+        };
+
+        CertificateRevocationList::from_params(crl_params).map_err(|err| {
+            AppError::GenWithMsgAndErr(
+                format!(
+                    "Error creating certificate revocation list: num={:?}",
+                    self.crl_number.as_ref().unwrap()
+                ),
+                Box::new(err),
+            )
+        })
+    }
+}
+
+impl Default for CertificateRevocationListBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Represents a certificate revocation list (CRL) file.
+/// Exposes the ability to re-parse entries when file has changed.
+pub struct CRLFile {
+    /// Path to CRL file
+    path: PathBuf,
+    /// Last modified file time (used to determine reloading)
+    last_mtime: SystemTime,
+    /// Last loaded CRL object list
+    crl_list: Arc<Mutex<Vec<CertificateRevocationListDer<'static>>>>,
+    /// Controls whether reloading loop is active
+    reloading: Arc<Mutex<bool>>,
+}
+
+impl CRLFile {
+    /// CRLFile constructor
+    ///
+    /// # Arguments
+    ///
+    /// * `filepath_str` - CRL file pathspec
+    /// * `crl_list` - CRL objects list (potentially updated on changes)
+    /// * `reloading` - Controls whether reloading loop is active
+    ///
+    /// # Returns
+    ///
+    /// A [`anyhow::Result`] containing the new constructed [`CRLFile`] object.
+    /// If the file path is not valid, will return an error.
+    ///
+    pub fn new(
+        filepath_str: &str,
+        crl_list: &Arc<Mutex<Vec<CertificateRevocationListDer<'static>>>>,
+        reloading: &Arc<Mutex<bool>>,
+    ) -> anyhow::Result<Self, AppError> {
+        let filepath = PathBuf::from_str(filepath_str).map_err(|err| {
+            AppError::GenWithMsgAndErr(
+                format!(
+                    "Error converting string to file path: file={}",
+                    filepath_str
+                ),
+                Box::new(err),
+            )
+        })?;
+        Ok(CRLFile {
+            path: filepath,
+            last_mtime: UNIX_EPOCH,
+            crl_list: crl_list.clone(),
+            reloading: reloading.clone(),
+        })
+    }
+
+    /// CRL list accessor
+    ///
+    /// # Returns
+    ///
+    /// The CRL objects list
+    ///
+    pub fn crl_list(&mut self) -> Arc<Mutex<Vec<CertificateRevocationListDer<'static>>>> {
+        self.crl_list.clone()
+    }
+}
+
+impl file::ReloadableFile for CRLFile {
+    fn filepath(&self) -> &PathBuf {
+        &self.path
+    }
+
+    fn last_file_mtime(&mut self) -> &mut SystemTime {
+        &mut self.last_mtime
+    }
+
+    fn on_reload_data(&mut self) -> anyhow::Result<(), AppError> {
+        match crypto::file::load_crl_list(self.path.to_str().unwrap()) {
+            Ok(list) => {
+                *self.crl_list.lock().unwrap().deref_mut() = rustls_pemfile::crls(
+                    &mut list.as_slice(),
+                )
+                .map(|result| {
+                    result.map_err(|err| {
+                        AppError::GenWithMsgAndErr(
+                            format!("Error reading CRL entries: file={:?}", &self.path),
+                            Box::new(err),
+                        )
+                    })
+                })
+                .collect::<anyhow::Result<Vec<CertificateRevocationListDer<'static>>, AppError>>(
+                )?;
+                Ok(())
+            }
+            Err(err) => Err(AppError::GenWithMsgAndErr(
+                format!("Error loading CRL file: file={:?}", &self.path),
+                Box::new(err),
+            )),
+        }
+    }
+
+    fn on_critical_error(&mut self, err: &AppError) {
+        panic!("Error during CRL reload, exiting: err={:?}", &err);
+    }
+
+    fn reloading(&self) -> &Arc<Mutex<bool>> {
+        &self.reloading
+    }
+}
+
+/// Unit tests
+#[cfg(test)]
+pub mod tests {
+
+    use super::*;
+    use crate::crypto::ca::SERIAL_NUMBER_MAX_OCTETS;
+    use crate::crypto::crl::CRLFile;
+    use crate::file::ReloadableFile;
+    use rcgen::{CrlDistributionPoint, CrlScope};
+    use std::path::PathBuf;
+    use time::macros::datetime;
+
+    const _CERTFILE_CLIENT0_PATHPARTS: [&str; 3] = [
+        env!("CARGO_MANIFEST_DIR"),
+        "testdata",
+        "client0.local.crt.pem",
+    ];
+    pub const CRLFILE_REVOKED_CERTS_0_PATHPARTS: [&str; 3] = [
+        env!("CARGO_MANIFEST_DIR"),
+        "testdata",
+        "revoked-crts-0.crl.pem",
+    ];
+    pub const CRLFILE_REVOKED_CERTS_0_1_PATHPARTS: [&str; 3] = [
+        env!("CARGO_MANIFEST_DIR"),
+        "testdata",
+        "revoked-crts-0-1.crl.pem",
+    ];
+    pub const CRLFILE_INVALID_PATHPARTS: [&str; 3] =
+        [env!("CARGO_MANIFEST_DIR"), "testdata", "invalid.crl.pem"];
+    pub const CRLFILE_MISSING_PATHPARTS: [&str; 3] =
+        [env!("CARGO_MANIFEST_DIR"), "testdata", "NON-EXISTENT.txt"];
+
+    #[test]
+    fn revokecert_default_and_thus_new() {
+        let builder = RevokedCertificateBuilder::default();
+        assert!(builder.serial_number.is_none());
+        assert!(builder.revocation_datetime.is_none());
+        assert!(builder.reason_code.is_none());
+        assert!(builder.invalidity_datetime.is_none());
+    }
+
+    #[test]
+    fn revokecert_build_when_missing_all_required_data() {
+        let builder = RevokedCertificateBuilder {
+            serial_number: None,
+            revocation_datetime: None,
+            reason_code: None,
+            invalidity_datetime: None,
+        };
+
+        let result = builder.build();
+
+        if result.is_ok() {
+            panic!("Unexpected successful result");
+        }
+
+        let err_str = format!("{:?}", result.err().unwrap());
+        assert!(err_str.contains(VALIDATION_MSG_CERTIFICATE_SERIAL_NUMBER_REQUIRED));
+        assert!(err_str.contains(VALIDATION_MSG_CERTIFICATE_REVOCATION_DATETIME_REQUIRED));
+    }
+
+    #[test]
+    fn revokecert_build_when_invalid_serial_number() {
+        let mut builder = RevokedCertificateBuilder {
+            serial_number: None,
+            revocation_datetime: Some(OffsetDateTime::now_utc()),
+            reason_code: Some(RevocationReason::KeyCompromise),
+            invalidity_datetime: Some(OffsetDateTime::now_utc()),
+        };
+
+        builder.serial_number(&[0u8; SERIAL_NUMBER_MAX_OCTETS + 1].to_vec());
+
+        let result = builder.build();
+
+        if result.is_ok() {
+            panic!("Unexpected successful result");
+        }
+
+        let err_str = format!("{:?}", result.err().unwrap());
+        assert!(err_str.contains(VALIDATION_MSG_SERIAL_NUMBER_LIMIT_EXCEEDED));
+    }
+
+    #[test]
+    fn revokecert_build_when_all_valid() {
+        let mut builder = RevokedCertificateBuilder {
+            serial_number: None,
+            revocation_datetime: None,
+            reason_code: None,
+            invalidity_datetime: None,
+        };
+
+        let result = builder
+            .serial_number(&[0u8, 1u8])
+            .revocation_datetime(&datetime!(2024-01-01 0:00 UTC))
+            .reason_code(&RevocationReason::KeyCompromise)
+            .invalidity_datetime(&datetime!(2024-02-01 0:00 UTC))
+            .build();
+
+        if let Err(err) = result {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+
+        let revoked_cert = result.unwrap();
+
+        assert_eq!(
+            &revoked_cert.serial_number,
+            &SerialNumber::from_slice(&[0u8, 1u8])
+        );
+        assert_eq!(
+            &revoked_cert.revocation_time,
+            &datetime!(2024-01-01 0:00 UTC)
+        );
+        assert!(revoked_cert.reason_code.is_some());
+        assert_eq!(
+            revoked_cert.reason_code.as_ref().unwrap(),
+            &RevocationReason::KeyCompromise
+        );
+        assert!(revoked_cert.invalidity_date.is_some());
+        assert_eq!(
+            revoked_cert.invalidity_date.as_ref().unwrap(),
+            &datetime!(2024-02-01 0:00 UTC)
+        );
+    }
+
+    #[test]
+    fn certrevokelist_default_and_thus_new() {
+        let builder = CertificateRevocationListBuilder::default();
+        assert!(builder.crl_number.is_none());
+        assert!(builder.update_datetime.is_none());
+        assert!(builder.next_update_datetime.is_none());
+        assert!(builder.issuing_distribution.is_none());
+        assert!(builder.signature_algorithm.is_none());
+        assert!(builder.key_ident_method.is_none());
+    }
+
+    #[test]
+    fn certrevokelist_build_when_missing_all_required_data() {
+        let mut builder = CertificateRevocationListBuilder {
+            crl_number: None,
+            update_datetime: None,
+            next_update_datetime: None,
+            issuing_distribution: None,
+            signature_algorithm: None,
+            key_ident_method: None,
+        };
+
+        let result = builder.build(vec![]);
+
+        if result.is_ok() {
+            panic!("Unexpected successful result");
+        }
+
+        let err_str = format!("{:?}", result.err().unwrap());
+        assert!(err_str.contains(VALIDATION_MSG_CRL_NUMBER_REQUIRED));
+        assert!(err_str.contains(VALIDATION_MSG_UPDATE_DATETIME_REQUIRED));
+        assert!(err_str.contains(VALIDATION_MSG_NEXT_UPDATE_DATETIME_REQUIRED));
+        assert!(err_str.contains(VALIDATION_MSG_SIGNATURE_ALGORITHM_REQUIRED));
+        assert!(err_str.contains(VALIDATION_MSG_KEY_IDENTIFIER_METHOD_REQUIRED));
+    }
+
+    #[test]
+    fn certrevokelist_build_when_invalid_serial_number() {
+        let mut builder = CertificateRevocationListBuilder {
+            crl_number: None,
+            update_datetime: Some(OffsetDateTime::now_utc()),
+            next_update_datetime: Some(OffsetDateTime::now_utc()),
+            issuing_distribution: None,
+            signature_algorithm: Some(ca::KeyAlgorithm::EcdsaP256),
+            key_ident_method: Some(KeyIdMethod::Sha256),
+        };
+
+        builder.crl_number(&[0u8; SERIAL_NUMBER_MAX_OCTETS + 1].to_vec());
+
+        let result = builder.build(vec![]);
+
+        if result.is_ok() {
+            panic!("Unexpected successful result");
+        }
+
+        let err_str = format!("{:?}", result.err().unwrap());
+        assert!(err_str.contains(VALIDATION_MSG_CRL_NUMBER_LIMIT_EXCEEDED));
+    }
+
+    #[test]
+    fn certrevokelist_build_when_all_valid() {
+        let dist_pt_uris = vec!["https://example.com/crl".to_string()];
+        let mut builder = CertificateRevocationListBuilder {
+            crl_number: None,
+            update_datetime: None,
+            next_update_datetime: None,
+            issuing_distribution: None,
+            signature_algorithm: None,
+            key_ident_method: None,
+        };
+
+        let result = builder
+            .crl_number(&[0u8, 1u8])
+            .update_datetime(&datetime!(2024-01-01 0:00 UTC))
+            .next_update_datetime(&datetime!(2024-02-01 0:00 UTC))
+            .issuing_distribution(CrlIssuingDistributionPoint {
+                distribution_point: CrlDistributionPoint {
+                    uris: dist_pt_uris.clone(),
+                },
+                scope: Some(CrlScope::UserCertsOnly),
+            })
+            .signature_algorithm(&ca::KeyAlgorithm::EcdsaP256)
+            .key_ident_method(KeyIdMethod::Sha256)
+            .build(vec![RevokedCertificateBuilder::new()
+                .serial_number(&[2u8, 3u8])
+                .revocation_datetime(&datetime!(2024-01-10 0:00 UTC))
+                .reason_code(&RevocationReason::KeyCompromise)
+                .invalidity_datetime(&datetime!(2024-02-10 0:00 UTC))
+                .build()
+                .unwrap()]);
+
+        if let Err(err) = result {
+            panic!("Unexpected result: err={:?}", &err);
+        }
+
+        let crl = result.unwrap();
+
+        assert_eq!(
+            &crl.get_params().crl_number,
+            &SerialNumber::from_slice(&[0u8, 1u8])
+        );
+        assert_eq!(
+            &crl.get_params().this_update,
+            &datetime!(2024-01-01 0:00 UTC)
+        );
+        assert_eq!(
+            &crl.get_params().next_update,
+            &datetime!(2024-02-01 0:00 UTC)
+        );
+        assert_eq!(crl.get_params().alg, &rcgen::PKCS_ECDSA_P256_SHA256);
+        assert_eq!(crl.get_params().key_identifier_method, KeyIdMethod::Sha256);
+
+        assert!(crl.get_params().issuing_distribution_point.is_some());
+        let issue_dist_pt = crl
+            .get_params()
+            .issuing_distribution_point
+            .as_ref()
+            .unwrap();
+        assert_eq!(issue_dist_pt.distribution_point.uris, dist_pt_uris);
+        assert!(issue_dist_pt.scope.is_some());
+        assert_eq!(
+            issue_dist_pt.scope.as_ref().unwrap(),
+            &CrlScope::UserCertsOnly
+        );
+
+        assert_eq!(crl.get_params().revoked_certs.len(), 1);
+        let revoked_cert = crl.get_params().revoked_certs.get(0).unwrap();
+        assert_eq!(
+            &revoked_cert.serial_number,
+            &SerialNumber::from_slice(&[2u8, 3u8])
+        );
+        assert_eq!(
+            &revoked_cert.revocation_time,
+            &datetime!(2024-01-10 0:00 UTC)
+        );
+        assert!(revoked_cert.reason_code.is_some());
+        assert_eq!(
+            revoked_cert.reason_code.as_ref().unwrap(),
+            &RevocationReason::KeyCompromise
+        );
+        assert!(revoked_cert.invalidity_date.is_some());
+        assert_eq!(
+            revoked_cert.invalidity_date.as_ref().unwrap(),
+            &datetime!(2024-02-10 0:00 UTC)
+        );
+    }
+
+    #[test]
+    fn crlfile_new() {
+        let crl_filepath: PathBuf = CRLFILE_REVOKED_CERTS_0_PATHPARTS.iter().collect();
+        let crl_filepath_str = crl_filepath.to_str().unwrap();
+        let crl_list = Arc::new(Mutex::new(vec![]));
+        let reloading = Arc::new(Mutex::new(false));
+
+        let crl_file = CRLFile::new(crl_filepath_str, &crl_list, &reloading).unwrap();
+
+        assert_eq!(
+            crl_file.path.to_str().unwrap().to_string(),
+            crl_filepath_str.to_string()
+        );
+        assert!(crl_file.crl_list.lock().unwrap().is_empty());
+        assert_eq!(*crl_file.reloading.lock().unwrap(), false);
+    }
+
+    #[test]
+    fn crlfile_accessors() {
+        let crl_filepath: PathBuf = CRLFILE_REVOKED_CERTS_0_PATHPARTS.iter().collect();
+        let crl_list = Arc::new(Mutex::new(vec![]));
+        let last_mtime = file::file_mtime(crl_filepath.as_path()).unwrap();
+
+        let mut crl_file = CRLFile {
+            path: crl_filepath.clone(),
+            last_mtime,
+            crl_list: crl_list.clone(),
+            reloading: Arc::new(Mutex::new(true)),
+        };
+
+        assert_eq!(*crl_file.filepath(), crl_filepath);
+        assert_eq!(*crl_file.last_file_mtime(), last_mtime);
+        assert!(*crl_file.reloading().lock().unwrap());
+    }
+
+    #[test]
+    fn crlfile_crl_list_when_invalid_filepath() {
+        let crl_filepath: PathBuf = CRLFILE_MISSING_PATHPARTS.iter().collect();
+        let crl_filepath_str = crl_filepath.to_str().unwrap();
+        let crl_list = Arc::new(Mutex::new(vec![]));
+        let reloading = Arc::new(Mutex::new(false));
+
+        let mut crl_file = CRLFile::new(crl_filepath_str, &crl_list, &reloading).unwrap();
+
+        let reload_result = crl_file.on_reload_data();
+        if let Ok(()) = reload_result {
+            panic!("Unexpected successful reload result");
+        }
+
+        let crl_list = crl_file.crl_list();
+
+        assert!(crl_list.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn crlfile_crl_list_when_invalid_crlfile() {
+        let crl_filepath: PathBuf = CRLFILE_INVALID_PATHPARTS.iter().collect();
+        let crl_filepath_str = crl_filepath.to_str().unwrap();
+        let crl_list = Arc::new(Mutex::new(vec![]));
+        let reloading = Arc::new(Mutex::new(false));
+
+        let mut crl_file = CRLFile::new(crl_filepath_str, &crl_list, &reloading).unwrap();
+
+        let reload_result = crl_file.on_reload_data();
+        if let Ok(()) = reload_result {
+            panic!("Unexpected successful reload result:");
+        }
+
+        let crl_list = crl_file.crl_list();
+
+        assert!(crl_list.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn crlfile_crl_list_when_valid_1_entry_crlfile() {
+        let crl_filepath: PathBuf = CRLFILE_REVOKED_CERTS_0_PATHPARTS.iter().collect();
+        let crl_filepath_str = crl_filepath.to_str().unwrap();
+        let crl_list = Arc::new(Mutex::new(vec![]));
+        let reloading = Arc::new(Mutex::new(false));
+
+        let mut crl_file = CRLFile::new(crl_filepath_str, &crl_list, &reloading).unwrap();
+
+        let reload_result = crl_file.on_reload_data();
+        if let Err(err) = reload_result {
+            panic!("Unexpected reload result: err={:?}", &err);
+        }
+
+        let crl_list = crl_file.crl_list();
+
+        assert!(!crl_list.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn crlfile_crl_list_when_valid_2_entry_crlfile() {
+        let crl_filepath: PathBuf = CRLFILE_REVOKED_CERTS_0_1_PATHPARTS.iter().collect();
+        let crl_filepath_str = crl_filepath.to_str().unwrap();
+        let crl_list = Arc::new(Mutex::new(vec![]));
+        let reloading = Arc::new(Mutex::new(false));
+
+        let mut crl_file = CRLFile::new(crl_filepath_str, &crl_list, &reloading).unwrap();
+
+        let reload_result = crl_file.on_reload_data();
+        if let Err(err) = reload_result {
+            panic!("Unexpected reload result: err={:?}", &err);
+        }
+
+        let crl_list = crl_file.crl_list();
+
+        assert!(!crl_list.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn crlfile_process_reload_when_file_unchanged() {
+        let crl_filepath: PathBuf = CRLFILE_REVOKED_CERTS_0_PATHPARTS.iter().collect();
+        let crl_filepath_str = crl_filepath.to_str().unwrap().to_string();
+        let crl_list = Arc::new(Mutex::new(vec![]));
+        let last_mtime = file::file_mtime(crl_filepath.as_path()).unwrap();
+        let saved_last_mtime = last_mtime.clone();
+
+        let mut crl_file = CRLFile {
+            path: crl_filepath,
+            last_mtime,
+            crl_list: crl_list.clone(),
+            reloading: Arc::new(Mutex::new(true)),
+        };
+
+        let result = crl_file.process_reload();
+        if let Err(err) = result {
+            panic!(
+                "Unexpected processed CRL list reload result: path={}, err={:?}",
+                &crl_filepath_str, &err
+            );
+        }
+        let was_reloaded = result.unwrap();
+
+        assert_eq!(was_reloaded, false);
+        assert_eq!(crl_file.last_mtime, saved_last_mtime);
+        assert!(crl_list.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn crlfile_process_reload_when_file_changed() {
+        let crl_filepath: PathBuf = CRLFILE_REVOKED_CERTS_0_PATHPARTS.iter().collect();
+        let crl_filepath_str = crl_filepath.to_str().unwrap().to_string();
+        let crl_list = Arc::new(Mutex::new(vec![]));
+        let last_mtime = SystemTime::now();
+        let saved_last_mtime = last_mtime.clone();
+
+        let mut crl_file = CRLFile {
+            path: crl_filepath,
+            last_mtime,
+            crl_list: crl_list.clone(),
+            reloading: Arc::new(Mutex::new(true)),
+        };
+
+        let result = crl_file.process_reload();
+        if let Err(err) = result {
+            panic!(
+                "Unexpected processed CRL list reload result: path={}, err={:?}",
+                &crl_filepath_str, &err
+            );
+        }
+        let was_reloaded = result.unwrap();
+
+        assert_eq!(was_reloaded, true);
+        assert_ne!(crl_file.last_mtime, saved_last_mtime);
+        assert!(!crl_list.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    #[should_panic]
+    fn crlfile_process_reload_when_invalid_filepath() {
+        let crl_filepath: PathBuf = CRLFILE_MISSING_PATHPARTS.iter().collect();
+        let crl_list = Arc::new(Mutex::new(vec![]));
+        let last_mtime = SystemTime::now();
+
+        let mut crl_file = CRLFile {
+            path: crl_filepath,
+            last_mtime,
+            crl_list: crl_list.clone(),
+            reloading: Arc::new(Mutex::new(true)),
+        };
+
+        let _ = crl_file.process_reload();
+    }
+
+    #[test]
+    fn crlfile_process_reload_when_invalid_crlfile() {
+        let crl_filepath: PathBuf = CRLFILE_INVALID_PATHPARTS.iter().collect();
+        let crl_filepath_str = crl_filepath.to_str().unwrap().to_string();
+        let crl_list = Arc::new(Mutex::new(vec![]));
+        let last_mtime = SystemTime::now();
+
+        let mut crl_file = CRLFile {
+            path: crl_filepath,
+            last_mtime,
+            crl_list: crl_list.clone(),
+            reloading: Arc::new(Mutex::new(true)),
+        };
+
+        let result = crl_file.process_reload();
+        if let Ok(was_reloaded) = result {
+            panic!(
+                "Unexpected processed CRL list reload result: path={}, reloaded={}",
+                &crl_filepath_str, &was_reloaded
+            );
+        }
+
+        assert!(crl_list.lock().unwrap().is_empty());
+    }
+}

--- a/crates/common/src/crypto/mod.rs
+++ b/crates/common/src/crypto/mod.rs
@@ -1,6 +1,7 @@
 pub mod alpn;
 pub mod asn;
 pub mod ca;
+pub mod crl;
 pub mod file;
 pub mod tls;
 pub mod x509;

--- a/crates/gateway/src/config.rs
+++ b/crates/gateway/src/config.rs
@@ -24,7 +24,7 @@ use rustls::server::danger::ClientCertVerifier;
 use rustls::server::WebPkiClientVerifier;
 use trust0_common::authn::authenticator::AuthnType;
 use trust0_common::crypto::alpn;
-use trust0_common::crypto::file::CRLFile;
+use trust0_common::crypto::crl::CRLFile;
 use trust0_common::crypto::file::{load_certificates, load_private_key};
 use trust0_common::error::AppError;
 use trust0_common::file::ReloadableFile;

--- a/docs/Examples.md
+++ b/docs/Examples.md
@@ -25,15 +25,15 @@ The following examples are provided in the `examples` directory:
 
 To run the examples, the following commands are required:
 
-| Facility       | Original tested version                   | Notes                                   |
-|----------------|-------------------------------------------|-----------------------------------------|
-| Rust toolchain | Linux, macOS: `1.74.0`, Windows: `1.75.0` |                                         |
-| `bash`         | Linux, macOS, Windows: `5.2.21`           | Code will assert version is 4 or higher |
-| `gmake`        | Linux, macOS, Windows: `4.4.1`            |                                         |
-| `openssl`      | Linux: `3.3.1`, macOS, Windows: `3.2.0`   |                                         |
-| `m4`           | Linux, Windows: `1.4.19` macOS: `1.4.6`   |                                         |
-| `tmux`         | Linux, macOS, Windows: `3.3a`             |                                         |
-| `ncat`         | Linux: `7.93`, macOS, Windows: `7.94`     | This can be found in the `nmap` package |
+| Facility       | Original tested version                   | Notes                                                                                   |
+|----------------|-------------------------------------------|-----------------------------------------------------------------------------------------|
+| Rust toolchain | Linux, macOS: `1.74.0`, Windows: `1.75.0` |                                                                                         |
+| `bash`         | Linux, macOS, Windows: `5.2.21`           | Code will assert version is 4 or higher                                                 |
+| `gmake`        | Linux, macOS, Windows: `4.4.1`            |                                                                                         |
+| `openssl`      | Linux: `3.3.1`, macOS, Windows: `3.2.0`   | This is not needed unless you change the example code to use the `OpenSSL` PKI provider |
+| `m4`           | Linux, Windows: `1.4.19` macOS: `1.4.6`   |                                                                                         |
+| `tmux`         | Linux, macOS, Windows: `3.3a`             |                                                                                         |
+| `ncat`         | Linux: `7.93`, macOS, Windows: `7.94`     | This can be found in the `nmap` package                                                 |
 
 If you wish to override the command used by the example script, merely supply the environment variable(s) for the respective commands (refer to `run-configure.sh` for a listing of command variables).  For example:
 

--- a/docs/Utilities.md
+++ b/docs/Utilities.md
@@ -7,6 +7,7 @@
       * [Create Root CA PKI Resources](#create-root-ca-pki-resources)
       * [Create Gateway PKI Resources](#create-gateway-pki-resources)
       * [Create Client PKI Resources](#create-client-pki-resources)
+      * [Create Certificate Revocation List File](#create-certificate-revocation-list-file)
 <!-- TOC -->
 
 ## Trust0 Utilities
@@ -279,12 +280,12 @@ Options:
           [env: KEY_FILE=]
 
       --rootca-cert-file <ROOTCA_CERT_FILE>
-          root CA certificate from <KEY_FILE>. This will be a PKCS#8 PEM-encoded certificate
+          Root CA certificate from <KEY_FILE>. This will be a PKCS#8 PEM-encoded certificate
           
           [env: ROOTCA_CERT_FILE=]
 
       --rootca-key-file <ROOTCA_KEY_FILE>
-          root CA private key from <KEY_FILE>. This will be a PKCS#8 PEM-encoded ECDSA or EdDSA key
+          Root CA private key from <KEY_FILE>. This will be a PKCS#8 PEM-encoded ECDSA or EdDSA key
           
           [env: ROOTCA_KEY_FILE=]
 
@@ -371,12 +372,12 @@ Options:
           [env: KEY_FILE=]
 
       --rootca-cert-file <ROOTCA_CERT_FILE>
-          root CA certificate from <KEY_FILE>. This will be a PKCS#8 PEM-encoded certificate
+          Root CA certificate from <KEY_FILE>. This will be a PKCS#8 PEM-encoded certificate
           
           [env: ROOTCA_CERT_FILE=]
 
       --rootca-key-file <ROOTCA_KEY_FILE>
-          root CA private key from <KEY_FILE>. This will be a PKCS#8 PEM-encoded ECDSA or EdDSA key
+          Root CA private key from <KEY_FILE>. This will be a PKCS#8 PEM-encoded ECDSA or EdDSA key
           
           [env: ROOTCA_KEY_FILE=]
 
@@ -439,4 +440,92 @@ Here is a simple invocation of this tool (CA certificate and key must be accessi
 ```
 <TRUST0_REPO>/target/debug$ ./trust0-pki-manager client-pki-creator --cert-file client.crt.pem --key-file client.key.pem --rootca-cert-file rootca.crt.pem --rootca-key-file rootca.key.pem --key-algorithm ecdsa-p256 --serial-number 03e8 --validity-not-after 2025-01-01T00:00:00Z --auth-user-id 100 --auth-platform Linux --subject-common-name user123 --subject-organization Example0 --subject-country US
 
+```
+
+#### Create Certificate Revocation List File
+
+The common crate has a PKI manager tool (`trust0-pki-manager`), which can be used to create valid Trust0 certificate revocation list files.
+
+Here is the usage description:
+
+```
+Create certificate revocation list file
+
+Usage: trust0-pki-manager cert-revocation-list-creator [OPTIONS] --file <FILE> --rootca-cert-file <ROOTCA_CERT_FILE> --rootca-key-file <ROOTCA_KEY_FILE> --key-algorithm <KEY_ALGORITHM> --crl-number <CRL_NUMBER> --update-datetime <UPDATE_DATETIME> --next-update-datetime <NEXT_UPDATE_DATETIME> --signature-algorithm <SIGNATURE_ALGORITHM> --cert-revocation-datetime <CERT_REVOCATION_DATETIME>
+
+Options:
+  -f, --file <FILE>
+          Store certificate revocation list to <FILE>
+          
+          [env: FILE=]
+
+      --rootca-cert-file <ROOTCA_CERT_FILE>
+          Root CA certificate from <KEY_FILE>. This will be a PKCS#8 PEM-encoded certificate
+          
+          [env: ROOTCA_CERT_FILE=]
+
+      --rootca-key-file <ROOTCA_KEY_FILE>
+          Root CA private key from <KEY_FILE>. This will be a PKCS#8 PEM-encoded ECDSA or EdDSA key
+          
+          [env: ROOTCA_KEY_FILE=]
+
+      --key-algorithm <KEY_ALGORITHM>
+          Private key algorithm
+          
+          [env: KEY_ALGORITHM=]
+
+          Possible values:
+          - ecdsa-p256: Elliptic curve P-256
+          - ecdsa-p384: Elliptic curve P-384
+          - ed25519:    Edwards curve DSA Ed25519
+
+      --crl-number <CRL_NUMBER>
+          CRL number, to uniquely identify certificate revocation list, up to 20 (hex character 0-F) octets
+          
+          [env: CRL_NUMBER=]
+
+      --update-datetime <UPDATE_DATETIME>
+          Issue datetime of this CRL (RFC3339 format, for example '2021-01-02T03:04:05Z')
+          
+          [env: UPDATE_DATETIME=]
+
+      --next-update-datetime <NEXT_UPDATE_DATETIME>
+          Datetime by which the next CRL will be issued (RFC3339 format, for example '2021-01-02T03:04:05Z')
+          
+          [env: NEXT_UPDATE_DATETIME=]
+
+      --signature-algorithm <SIGNATURE_ALGORITHM>
+          Algorithm used by the CRL issuer to sign the certificate list
+          
+          [env: SIGNATURE_ALGORITHM=]
+
+          Possible values:
+          - ecdsa-p256: Elliptic curve P-256
+          - ecdsa-p384: Elliptic curve P-384
+          - ed25519:    Edwards curve DSA Ed25519
+
+      --cert-revocation-datetime <CERT_REVOCATION_DATETIME>
+          Datetime at which the CA processed the revocation (RFC3339 format, for example '2021-01-02T03:04:05Z')
+          
+          [env: CERT_REVOCATION_DATETIME=]
+
+      --cert-revocation-reason <CERT_REVOCATION_REASON>
+          (Optional) Reason for the certificate(s) revocation
+          
+          [env: CERT_REVOCATION_REASON=]
+          [possible values: unspecified, key-compromise, ca-compromise, affiliation-changed, superseded, cessation-of-operation, certificate-hold, remove-from-crl, privilege-withdrawn, aa-compromise]
+
+      --cert-revocation-serial-nums <CERT_REVOCATION_SERIAL_NUMS>
+          List of serial numbers for each revoked certificate (each value is a hex (0-F) string up to 20 characters). Defaults to empty list
+          
+          [env: CERT_REVOCATION_SERIAL_NUMS=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+```
+
+Here is a simple invocation of this tool (CA certificate and key must be accessible) creating a CRL revoking the certificate with serial number `03a8`:
+
+```
+<TRUST0_REPO>/target/debug$ ./trust0-pki-manager cert-revocation-list-creator --file revoked.crl.pem --rootca-cert-file rootca.crt.pem --rootca-key-file rootca.key.pem --key-algorithm ecdsa-p256 --crl-number 0100 --update-datetime 2024-01-01T00:00:00Z --next-update-datetime 2050-01-01T00:00:00Z --signature-algorithm ecdsa-p256 --cert-revocation-datetime 2024-01-01T00:00:00Z --cert-revocation-reason key-compromise --cert-revocation-serial-nums 03e8
 ```

--- a/example/Makefile
+++ b/example/Makefile
@@ -9,8 +9,11 @@ PROJECT_DIR=${EXAMPLE_DIR}/..
 PROJECT_RESOURCES_DIR=${PROJECT_DIR}/resources
 
 CARGO_CMD=cargo
-OPENSSL_CMD=openssl
 TRUST0_ADMIN_CMD=${PROJECT_RESOURCES_DIR}/trust0-admin.sh
+
+PKI_PROVIDER_OPENSSL=openssl
+PKI_PROVIDER_TRUST0=trust0
+PKI_PROVIDER=${PKI_PROVIDER_TRUST0}
 
 CARGOBUILD_EXTRA_ARGS=
 EXECBIN_EXTRA_ARGS=
@@ -20,6 +23,7 @@ include ${EXAMPLE_CONFIG_FILE}
 # Params - Certificate Authority
 
 ROOT_CA__PKI_NAME=example-ca.local
+ROOT_CA__PKI_VALID_NOT_AFTER=2100-01-01T00:00:00Z
 ROOT_CA__PKI_SUBJ_COUNTRY=US
 ROOT_CA__PKI_SUBJ_STATE=CA
 ROOT_CA__PKI_SUBJ_CITY=Nowhere
@@ -35,6 +39,8 @@ ROOT_CA__PKI_CRLNUMBER_FILE=${EXAMPLE_BUILD_DIR}/ca-crlnumber.txt
 # Params - Trust Gateway
 
 TRUST0_GATEWAY__PKI_NAME=example-gateway.local
+TRUST0_GATEWAY__PKI_VALID_NOT_AFTER=2100-01-01T00:00:00Z
+TRUST0_GATEWAY__PKI_SERIAL_NUM=03e7
 TRUST0_GATEWAY__PKI_SUBJ_COUNTRY=US
 TRUST0_GATEWAY__PKI_SUBJ_STATE=CA
 TRUST0_GATEWAY__PKI_SUBJ_CITY=Nowhere0
@@ -56,6 +62,8 @@ TRUST0_GATEWAY__SERVICE_HOST=${TRUST0_GATEWAY__HOST}
 # Params - Trust Client
 
 TRUST0_CLIENT__PKI_NAME=example-client.local
+TRUST0_CLIENT__PKI_VALID_NOT_AFTER=2100-01-01T00:00:00Z
+TRUST0_CLIENT__PKI_SERIAL_NUM=03e8
 TRUST0_CLIENT__PKI_SUBJ_COUNTRY=US
 TRUST0_CLIENT__PKI_SUBJ_STATE=CA
 TRUST0_CLIENT__PKI_SUBJ_CITY=Nowhere1
@@ -83,24 +91,9 @@ DATASOURCE_INMEMDB_USER_FILE=${EXAMPLE_BUILD_DIR}/example-db-user.json
 CRLSUPPORT__PKI_GATEWAY_CONFIGURED_FILE=${EXAMPLE_BUILD_DIR}/revoked.crl.pem
 CRLSUPPORT__PKI_REVOKE_CLIENT_FILE=${EXAMPLE_BUILD_DIR}/revoked-${TRUST0_CLIENT__PKI_NAME}.crl.pem
 
-# Params - Key Algorithm
-
-KEYALG_RSA_TYPE=rsa
-KEYALG_RSA_PARAMS=4096
-KEYALG_EC_TYPE=ec
-KEYALG_EC_PARAMS=${EXAMPLE_BUILD_DIR}/ecparams.pem
-#KEYALG_EC_CURVE=secp384r1
-KEYALG_EC_CURVE=prime256v1
-KEYALG_ED_TYPE=ed
-KEYALG_ED_PARAMS=ed25519
-
-# Update these 2 values to switch key algorithm type and params
-KEYALG_TYPE=${KEYALG_RSA_TYPE}
-KEYALG_PARAMS=${KEYALG_RSA_PARAMS}
-
 # Targets
 
-.PHONY: default clean-all root-ca-pki generate-root-ca-pki-resources gateway-server-pki generate-gateway-pki-resources client-pki generate-client-pki-resources trust0-gateway trust0-client run-trust0-gateway run-trust0-client run-trust0-gateway-nodeps run-trust0-client-nodeps setup-crl-files
+.PHONY: default clean-all trust0-common root-ca-pki generate-root-ca-pki-resources gateway-server-pki generate-gateway-pki-resources client-pki generate-client-pki-resources trust0-gateway trust0-client run-trust0-gateway run-trust0-client run-trust0-gateway-nodeps run-trust0-client-nodeps setup-crl-files
 
 default:
 
@@ -109,7 +102,7 @@ clean-all:
 	@rm -f ${EXAMPLE_BUILD_DIR}/*.pem
 	@rm -f ${EXAMPLE_BUILD_DIR}/*.pem.conf
 	@rm -f ${EXAMPLE_BUILD_DIR}/*.pem.csr.conf
-	@rm -f ${EXAMPLE_BUILD_DIR}/*.pem.csr
+	@rm -f ${EXAMPLE_BUILD_DIR}/*.pem.csr-
 	@rm -f ${ROOT_CA__PKI_CRL_CONF_FILE}
 	@rm -f ${ROOT_CA__PKI_DATABASE_FILE}
 	@rm -f ${ROOT_CA__PKI_DATABASE_FILE}.*
@@ -121,46 +114,29 @@ clean-all:
 ${EXAMPLE_CONFIG_FILE}:
 	@(test -f "$@" || (echo "Example configuration file '$@' unavailable. Please run '${EXAMPLE_DIR}/run-configure.sh'" && exit 1))
 
+trust0-common:
+	${CARGO_CMD} build --color=always --manifest-path ${PROJECT_DIR}/crates/common/Cargo.toml
+
+# Targets - PKI Provider
+
+ifeq ($(PKI_PROVIDER),$(PKI_PROVIDER_OPENSSL))
+  include ${EXAMPLE_DIR}/pki-provider-openssl.mk
+else
+  include ${EXAMPLE_DIR}/pki-provider-trust0.mk
+endif
+
 # Targets - ROOT CA
 
-generate-root-ca-pki-resources: ${EXAMPLE_CONFIG_FILE}
-	@echo "Creating root CA PKI resources"
-	@([ '${KEYALG_TYPE}' != '${KEYALG_EC_TYPE}' ] || [ -f ${KEYALG_PARAMS} ] || ${OPENSSL_CMD} ecparam -name ${KEYALG_EC_CURVE} -out ${KEYALG_PARAMS})
-	cd ${EXAMPLE_BUILD_DIR} && ${TRUST0_ADMIN_CMD} rootca-pki-creator --rootca-cert-filepath ${ROOT_CA__PKI_CERT_FILE} --rootca-key-filepath ${ROOT_CA__PKI_KEY_FILE} --key-algorithm ${KEYALG_TYPE}:${KEYALG_PARAMS} --subj-common-name ${ROOT_CA__PKI_SUBJ_COMMONNAME} --subj-country ${ROOT_CA__PKI_SUBJ_COUNTRY} --subj-state ${ROOT_CA__PKI_SUBJ_STATE} --subj-city ${ROOT_CA__PKI_SUBJ_CITY} --subj-company ${ROOT_CA__PKI_SUBJ_COMPANY} --subj-dept ${ROOT_CA__PKI_SUBJ_DEPT}
-	@echo ""
-
-.ONESHELL:
-${ROOT_CA__PKI_CRL_CONF_FILE}: ${EXAMPLE_CONFIG_FILE}
-	@echo "Creating $@"
-	@cat <<- EOF > $@
-		[ ca ]
-		default_ca = ca_default
-		[ ca_default ]
-		database = ${ROOT_CA__PKI_DATABASE_FILE}
-		crlnumber = ${ROOT_CA__PKI_CRLNUMBER_FILE}
-		default_md = default
-		crl_extensions = crl_ext
-		[ crl_ext ]
-		authorityKeyIdentifier = keyid,issuer
-		EOF
-	@echo ""
-
-root-ca-pki: generate-root-ca-pki-resources ${ROOT_CA__PKI_CRL_CONF_FILE}
+root-ca-pki: generate-root-ca-pki-resources
 
 # Targets - Trust Gateway
 
-generate-gateway-pki-resources: ${EXAMPLE_CONFIG_FILE}
-	@echo "Creating gateway PKI resources"
-	@([ '${KEYALG_TYPE}' != '${KEYALG_EC_TYPE}' ] || [ -f ${KEYALG_PARAMS} ] || ${OPENSSL_CMD} ecparam -name ${KEYALG_EC_CURVE} -out ${KEYALG_PARAMS})
-	cd ${EXAMPLE_BUILD_DIR} && ${TRUST0_ADMIN_CMD} gateway-pki-creator --gateway-cert-filepath ${TRUST0_GATEWAY__PKI_CERT_FILE} --gateway-key-filepath ${TRUST0_GATEWAY__PKI_KEY_FILE} --ca-cert-filepath ${ROOT_CA__PKI_CERT_FILE} --ca-key-filepath ${ROOT_CA__PKI_KEY_FILE} --key-algorithm ${KEYALG_TYPE}:${KEYALG_PARAMS} --subj-common-name ${TRUST0_GATEWAY__PKI_SUBJ_COMMONNAME} --subj-country ${TRUST0_GATEWAY__PKI_SUBJ_COUNTRY} --subj-state ${TRUST0_GATEWAY__PKI_SUBJ_STATE} --subj-city ${TRUST0_GATEWAY__PKI_SUBJ_CITY} --subj-company ${TRUST0_GATEWAY__PKI_SUBJ_COMPANY} --subj-dept ${TRUST0_GATEWAY__PKI_SUBJ_DEPT} --san-dns1 ${TRUST0_GATEWAY__PKI_HOST_DNS1} --san-dns2 ${TRUST0_GATEWAY__PKI_HOST_DNS2}
-	@echo ""
+gateway-server-pki: generate-gateway-pki-resources
 
-gateway-server-pki: generate-root-ca-pki-resources generate-gateway-pki-resources
-
-trust0-gateway:
+trust0-gateway: trust0-common
 	${CARGO_CMD} build --color=always --bin trust0-gateway --manifest-path ${PROJECT_DIR}/crates/gateway/Cargo.toml ${CARGOBUILD_EXTRA_ARGS}
 
-run-trust0-gateway: gateway-server-pki trust0-gateway
+run-trust0-gateway: trust0-gateway
 	${TRUST0_GATEWAY__BINARY_FILE} --host ${TRUST0_GATEWAY__BIND_HOST} --port ${TRUST0_GATEWAY__PORT} --cert-file ${TRUST0_GATEWAY__PKI_CERT_FILE} --key-file ${TRUST0_GATEWAY__PKI_KEY_FILE} --auth-cert-file ${ROOT_CA__PKI_CERT_FILE} --gateway-service-host ${TRUST0_GATEWAY__SERVICE_HOST} ${EXECBIN_EXTRA_ARGS} --datasource in-memory-db --access-db-connect ${DATASOURCE_INMEMDB_ACCESS_FILE} --service-db-connect ${DATASOURCE_INMEMDB_SERVICE_FILE} --role-db-connect ${DATASOURCE_INMEMDB_ROLE_FILE} --user-db-connect ${DATASOURCE_INMEMDB_USER_FILE}
 
 run-trust0-gateway-nodeps:
@@ -168,29 +144,13 @@ run-trust0-gateway-nodeps:
 
 # Targets - Trust Client
 
-generate-client-pki-resources: ${EXAMPLE_CONFIG_FILE}
-	@echo "Creating client PKI resources"
-	@([ '${KEYALG_TYPE}' != '${KEYALG_EC_TYPE}' ] || [ -f ${KEYALG_PARAMS} ] || ${OPENSSL_CMD} ecparam -name ${KEYALG_EC_CURVE} -out ${KEYALG_PARAMS})
-	cd ${EXAMPLE_BUILD_DIR} && ${TRUST0_ADMIN_CMD} client-pki-creator --client-cert-filepath ${TRUST0_CLIENT__PKI_CERT_FILE} --client-key-filepath ${TRUST0_CLIENT__PKI_KEY_FILE} --ca-cert-filepath ${ROOT_CA__PKI_CERT_FILE} --ca-key-filepath ${ROOT_CA__PKI_KEY_FILE} --key-algorithm ${KEYALG_TYPE}:${KEYALG_PARAMS} --auth-user-id ${TRUST0_CLIENT__PKI_SUBJ_USERID} --auth-platform ${TRUST0_CLIENT__PKI_SUBJ_PLATFORM} --subj-common-name ${TRUST0_CLIENT__PKI_SUBJ_COMMONNAME} --subj-country ${TRUST0_CLIENT__PKI_SUBJ_COUNTRY} --subj-state ${TRUST0_CLIENT__PKI_SUBJ_STATE} --subj-city ${TRUST0_CLIENT__PKI_SUBJ_CITY} --subj-company ${TRUST0_CLIENT__PKI_SUBJ_COMPANY} --subj-dept ${TRUST0_CLIENT__PKI_SUBJ_DEPT}
-	@echo ""
+client-pki: generate-client-pki-resources
 
-client-pki: generate-root-ca-pki-resources generate-client-pki-resources
-
-trust0-client:
+trust0-client: trust0-common
 	${CARGO_CMD} build --color=always --bin trust0-client --manifest-path ${PROJECT_DIR}/crates/client/Cargo.toml ${CARGOBUILD_EXTRA_ARGS}
 
-run-trust0-client: trust0-client client-pki
+run-trust0-client: trust0-client
 	${TRUST0_CLIENT__BINARY_FILE} --host ${TRUST0_CLIENT__BIND_HOST} --gateway-host ${TRUST0_GATEWAY__HOST} --gateway-port ${TRUST0_GATEWAY__PORT} --auth-key-file ${TRUST0_CLIENT__PKI_KEY_FILE} --auth-cert-file ${TRUST0_CLIENT__PKI_CERT_FILE} --ca-root-cert-file ${ROOT_CA__PKI_CERT_FILE} ${EXECBIN_EXTRA_ARGS}
 
 run-trust0-client-nodeps:
 	${TRUST0_CLIENT__BINARY_FILE} --host ${TRUST0_CLIENT__BIND_HOST} --gateway-host ${TRUST0_GATEWAY__HOST} --gateway-port ${TRUST0_GATEWAY__PORT} --auth-key-file ${TRUST0_CLIENT__PKI_KEY_FILE} --auth-cert-file ${TRUST0_CLIENT__PKI_CERT_FILE} --ca-root-cert-file ${ROOT_CA__PKI_CERT_FILE} ${EXECBIN_EXTRA_ARGS}
-
-# Targets - CRL
-
-setup-crl-files: root-ca-pki client-pki
-	@echo -n '' > ${ROOT_CA__PKI_DATABASE_FILE}
-	@echo '1000' > ${ROOT_CA__PKI_CRLNUMBER_FILE}
-	@rm -f ${CRLSUPPORT__PKI_REVOKE_CLIENT_FILE}
-	@touch ${CRLSUPPORT__PKI_GATEWAY_CONFIGURED_FILE}
-	cd ${TESTDATA_BUILD_DIR} && ${OPENSSL_CMD} ca -config ${ROOT_CA__PKI_CRL_CONF_FILE} -keyfile ${ROOT_CA__PKI_KEY_FILE} -cert ${ROOT_CA__PKI_CERT_FILE} -gencrl -crldays 7 -revoke ${TRUST0_CLIENT__PKI_CERT_FILE} -crl_reason keyCompromise -out ${CRLSUPPORT__PKI_REVOKE_CLIENT_FILE}
-	cd ${TESTDATA_BUILD_DIR} && ${OPENSSL_CMD} ca -config ${ROOT_CA__PKI_CRL_CONF_FILE} -keyfile ${ROOT_CA__PKI_KEY_FILE} -cert ${ROOT_CA__PKI_CERT_FILE} -gencrl -crldays 7 -out ${CRLSUPPORT__PKI_REVOKE_CLIENT_FILE}

--- a/example/pki-provider-openssl.mk
+++ b/example/pki-provider-openssl.mk
@@ -1,0 +1,67 @@
+OPENSSL_CMD=openssl
+
+# Params - Key Algorithm
+
+OPENSSL_KEYALG_RSA_TYPE=rsa
+OPENSSL_KEYALG_RSA_PARAMS=4096
+OPENSSL_KEYALG_EC_TYPE=ec
+OPENSSL_KEYALG_EC_PARAMS=${EXAMPLE_BUILD_DIR}/ecparams.pem
+#OPENSSL_KEYALG_EC_CURVE=secp384r1
+OPENSSL_KEYALG_EC_CURVE=prime256v1
+OPENSSL_KEYALG_ED_TYPE=ed
+OPENSSL_KEYALG_ED_PARAMS=ed25519
+
+# Update these 2 values to switch key algorithm type and params
+OPENSSL_KEYALG_TYPE=${OPENSSL_KEYALG_RSA_TYPE}
+OPENSSL_KEYALG_PARAMS=${OPENSSL_KEYALG_RSA_PARAMS}
+
+# PKI Provider Targets - ROOT CA
+
+generate-root-ca-pki-resources: ${ROOT_CA__PKI_CRL_CONF_FILE}
+	@echo "Creating root CA PKI resources"
+	@([ '${OPENSSL_KEYALG_TYPE}' != '${OPENSSL_KEYALG_EC_TYPE}' ] || [ -f ${OPENSSL_KEYALG_PARAMS} ] || ${OPENSSL_CMD} ecparam -name ${OPENSSL_KEYALG_EC_CURVE} -out ${OPENSSL_KEYALG_PARAMS})
+	cd ${EXAMPLE_BUILD_DIR} && ${TRUST0_ADMIN_CMD} rootca-pki-creator --rootca-cert-filepath ${ROOT_CA__PKI_CERT_FILE} --rootca-key-filepath ${ROOT_CA__PKI_KEY_FILE} --key-algorithm ${OPENSSL_KEYALG_TYPE}:${OPENSSL_KEYALG_PARAMS} --subj-common-name ${ROOT_CA__PKI_SUBJ_COMMONNAME} --subj-country ${ROOT_CA__PKI_SUBJ_COUNTRY} --subj-state ${ROOT_CA__PKI_SUBJ_STATE} --subj-city ${ROOT_CA__PKI_SUBJ_CITY} --subj-company ${ROOT_CA__PKI_SUBJ_COMPANY} --subj-dept ${ROOT_CA__PKI_SUBJ_DEPT}
+	@echo ""
+
+.ONESHELL:
+${ROOT_CA__PKI_CRL_CONF_FILE}: ${EXAMPLE_CONFIG_FILE}
+	@echo "Creating $@"
+	@cat <<- EOF > $@
+		[ ca ]
+		default_ca = ca_default
+		[ ca_default ]
+		database = ${ROOT_CA__PKI_DATABASE_FILE}
+		crlnumber = ${ROOT_CA__PKI_CRLNUMBER_FILE}
+		default_md = default
+		crl_extensions = crl_ext
+		[ crl_ext ]
+		authorityKeyIdentifier = keyid,issuer
+		EOF
+	@echo ""
+
+# PKI Provider Targets - Trust Gateway
+
+generate-gateway-pki-resources: ${EXAMPLE_CONFIG_FILE}
+	@echo "Creating gateway PKI resources"
+	@([ '${OPENSSL_KEYALG_TYPE}' != '${OPENSSL_KEYALG_EC_TYPE}' ] || [ -f ${OPENSSL_KEYALG_PARAMS} ] || ${OPENSSL_CMD} ecparam -name ${OPENSSL_KEYALG_EC_CURVE} -out ${OPENSSL_KEYALG_PARAMS})
+	cd ${EXAMPLE_BUILD_DIR} && ${TRUST0_ADMIN_CMD} gateway-pki-creator --gateway-cert-filepath ${TRUST0_GATEWAY__PKI_CERT_FILE} --gateway-key-filepath ${TRUST0_GATEWAY__PKI_KEY_FILE} --ca-cert-filepath ${ROOT_CA__PKI_CERT_FILE} --ca-key-filepath ${ROOT_CA__PKI_KEY_FILE} --key-algorithm ${OPENSSL_KEYALG_TYPE}:${OPENSSL_KEYALG_PARAMS} --subj-common-name ${TRUST0_GATEWAY__PKI_SUBJ_COMMONNAME} --subj-country ${TRUST0_GATEWAY__PKI_SUBJ_COUNTRY} --subj-state ${TRUST0_GATEWAY__PKI_SUBJ_STATE} --subj-city ${TRUST0_GATEWAY__PKI_SUBJ_CITY} --subj-company ${TRUST0_GATEWAY__PKI_SUBJ_COMPANY} --subj-dept ${TRUST0_GATEWAY__PKI_SUBJ_DEPT} --san-dns1 ${TRUST0_GATEWAY__PKI_HOST_DNS1} --san-dns2 ${TRUST0_GATEWAY__PKI_HOST_DNS2}
+	@echo ""
+
+# PKI Provider Targets - Trust Client
+
+generate-client-pki-resources: ${EXAMPLE_CONFIG_FILE}
+	@echo "Creating client PKI resources"
+	@([ '${OPENSSL_KEYALG_TYPE}' != '${OPENSSL_KEYALG_EC_TYPE}' ] || [ -f ${OPENSSL_KEYALG_PARAMS} ] || ${OPENSSL_CMD} ecparam -name ${OPENSSL_KEYALG_EC_CURVE} -out ${OPENSSL_KEYALG_PARAMS})
+	cd ${EXAMPLE_BUILD_DIR} && ${TRUST0_ADMIN_CMD} client-pki-creator --client-cert-filepath ${TRUST0_CLIENT__PKI_CERT_FILE} --client-key-filepath ${TRUST0_CLIENT__PKI_KEY_FILE} --ca-cert-filepath ${ROOT_CA__PKI_CERT_FILE} --ca-key-filepath ${ROOT_CA__PKI_KEY_FILE} --key-algorithm ${OPENSSL_KEYALG_TYPE}:${OPENSSL_KEYALG_PARAMS} --auth-user-id ${TRUST0_CLIENT__PKI_SUBJ_USERID} --auth-platform ${TRUST0_CLIENT__PKI_SUBJ_PLATFORM} --subj-common-name ${TRUST0_CLIENT__PKI_SUBJ_COMMONNAME} --subj-country ${TRUST0_CLIENT__PKI_SUBJ_COUNTRY} --subj-state ${TRUST0_CLIENT__PKI_SUBJ_STATE} --subj-city ${TRUST0_CLIENT__PKI_SUBJ_CITY} --subj-company ${TRUST0_CLIENT__PKI_SUBJ_COMPANY} --subj-dept ${TRUST0_CLIENT__PKI_SUBJ_DEPT}
+	@echo ""
+
+# PKI Provider Targets - CRL
+
+setup-crl-files:
+	@echo "Creating certificate revocation list file"
+	@echo -n '' > ${ROOT_CA__PKI_DATABASE_FILE}
+	@echo '1000' > ${ROOT_CA__PKI_CRLNUMBER_FILE}
+	@rm -f ${CRLSUPPORT__PKI_REVOKE_CLIENT_FILE}
+	@touch ${CRLSUPPORT__PKI_GATEWAY_CONFIGURED_FILE}
+	cd ${TESTDATA_BUILD_DIR} && ${OPENSSL_CMD} ca -config ${ROOT_CA__PKI_CRL_CONF_FILE} -keyfile ${ROOT_CA__PKI_KEY_FILE} -cert ${ROOT_CA__PKI_CERT_FILE} -gencrl -crldays 7 -revoke ${TRUST0_CLIENT__PKI_CERT_FILE} -crl_reason keyCompromise -out ${CRLSUPPORT__PKI_REVOKE_CLIENT_FILE}
+	cd ${TESTDATA_BUILD_DIR} && ${OPENSSL_CMD} ca -config ${ROOT_CA__PKI_CRL_CONF_FILE} -keyfile ${ROOT_CA__PKI_KEY_FILE} -cert ${ROOT_CA__PKI_CERT_FILE} -gencrl -crldays 7 -out ${CRLSUPPORT__PKI_REVOKE_CLIENT_FILE}

--- a/example/pki-provider-trust0.mk
+++ b/example/pki-provider-trust0.mk
@@ -1,0 +1,46 @@
+TRUST0_PKI_MANAGER_CMD=${PROJECT_DIR}/target/debug/trust0-pki-manager
+
+# Params - CRL
+
+CRLSUPPORT__PKI_CRL_NUMBER=0100
+CRLSUPPORT__PKI_UPDATE_DATETIME=2024-01-01T00:00:00Z
+CRLSUPPORT__PKI_NEXT_UPDATE_DATETIME=2050-01-01T00:00:00Z
+CRLSUPPORT__PKI_CERT_REVOCATION_DATETIME=${CRLSUPPORT__PKI_UPDATE_DATETIME}
+CRLSUPPORT__PKI_CERT_REVOCATION_REASON=key-compromise
+CRLSUPPORT__PKI_CERT_REVOCATION_SERIAL_NUMS=${TRUST0_CLIENT__PKI_SERIAL_NUM}
+
+# Params - Key Algorithm
+
+TRUST0_KEYALG_TYPE=ecdsa-p256
+#TRUST0_KEYALG_TYPE=ecdsa-p384
+#TRUST0_KEYALG_TYPE=ed25519
+
+# PKI Provider Targets - ROOT CA
+
+generate-root-ca-pki-resources: ${EXAMPLE_CONFIG_FILE}
+	@echo "Creating root CA PKI resources"
+	cd ${EXAMPLE_BUILD_DIR} && ${TRUST0_PKI_MANAGER_CMD} root-ca-pki-creator --cert-file ${ROOT_CA__PKI_CERT_FILE} --key-file ${ROOT_CA__PKI_KEY_FILE} --key-algorithm ${TRUST0_KEYALG_TYPE} --validity-not-after ${ROOT_CA__PKI_VALID_NOT_AFTER} --subject-common-name ${ROOT_CA__PKI_SUBJ_COMMONNAME} --subject-organization ${ROOT_CA__PKI_SUBJ_COMPANY} --subject-country ${ROOT_CA__PKI_SUBJ_COUNTRY}
+	@echo ""
+
+# PKI Provider Targets - Trust Gateway
+
+generate-gateway-pki-resources: ${EXAMPLE_CONFIG_FILE}
+	@echo "Creating gateway PKI resources"
+	cd ${EXAMPLE_BUILD_DIR} && ${TRUST0_PKI_MANAGER_CMD} gateway-pki-creator --cert-file ${TRUST0_GATEWAY__PKI_CERT_FILE} --key-file ${TRUST0_GATEWAY__PKI_KEY_FILE} --rootca-cert-file ${ROOT_CA__PKI_CERT_FILE} --rootca-key-file ${ROOT_CA__PKI_KEY_FILE} --key-algorithm ${TRUST0_KEYALG_TYPE} --serial-number ${TRUST0_GATEWAY__PKI_SERIAL_NUM} --validity-not-after ${TRUST0_GATEWAY__PKI_VALID_NOT_AFTER} --subject-common-name ${TRUST0_GATEWAY__PKI_SUBJ_COMMONNAME} --subject-organization ${TRUST0_GATEWAY__PKI_SUBJ_COMPANY} --subject-country ${TRUST0_GATEWAY__PKI_SUBJ_COUNTRY} --san-dns-names ${TRUST0_GATEWAY__PKI_HOST_DNS1},${TRUST0_GATEWAY__PKI_HOST_DNS2}
+	@echo ""
+
+# PKI Provider Targets - Trust Client
+
+generate-client-pki-resources: ${EXAMPLE_CONFIG_FILE}
+	@echo "Creating client PKI resources"
+	cd ${EXAMPLE_BUILD_DIR} && ${TRUST0_PKI_MANAGER_CMD} client-pki-creator --cert-file ${TRUST0_CLIENT__PKI_CERT_FILE} --key-file ${TRUST0_CLIENT__PKI_KEY_FILE} --rootca-cert-file ${ROOT_CA__PKI_CERT_FILE} --rootca-key-file ${ROOT_CA__PKI_KEY_FILE} --key-algorithm ${TRUST0_KEYALG_TYPE} --serial-number ${TRUST0_CLIENT__PKI_SERIAL_NUM} --validity-not-after ${TRUST0_CLIENT__PKI_VALID_NOT_AFTER} --auth-user-id ${TRUST0_CLIENT__PKI_SUBJ_USERID} --auth-platform ${TRUST0_CLIENT__PKI_SUBJ_PLATFORM} --subject-common-name ${TRUST0_CLIENT__PKI_SUBJ_COMMONNAME} --subject-organization ${TRUST0_CLIENT__PKI_SUBJ_COMPANY} --subject-country ${TRUST0_CLIENT__PKI_SUBJ_COUNTRY}
+	@echo ""
+
+# PKI Provider Targets - CRL
+
+setup-crl-files:
+	@echo "Creating certificate revocation list file"
+	@rm -f ${CRLSUPPORT__PKI_REVOKE_CLIENT_FILE}
+	@touch ${CRLSUPPORT__PKI_GATEWAY_CONFIGURED_FILE}
+	cd ${EXAMPLE_BUILD_DIR} && ${TRUST0_PKI_MANAGER_CMD} cert-revocation-list-creator --file ${CRLSUPPORT__PKI_REVOKE_CLIENT_FILE} --rootca-cert-file ${ROOT_CA__PKI_CERT_FILE} --rootca-key-file ${ROOT_CA__PKI_KEY_FILE} --key-algorithm ${TRUST0_KEYALG_TYPE} --crl-number ${CRLSUPPORT__PKI_CRL_NUMBER} --update-datetime ${CRLSUPPORT__PKI_UPDATE_DATETIME} --next-update-datetime ${CRLSUPPORT__PKI_NEXT_UPDATE_DATETIME} --signature-algorithm ${TRUST0_KEYALG_TYPE} --cert-revocation-datetime ${CRLSUPPORT__PKI_CERT_REVOCATION_DATETIME} --cert-revocation-reason ${CRLSUPPORT__PKI_CERT_REVOCATION_REASON} --cert-revocation-serial-nums ${CRLSUPPORT__PKI_CERT_REVOCATION_SERIAL_NUMS}
+	@echo ""

--- a/example/run-chat-tcp-example.sh
+++ b/example/run-chat-tcp-example.sh
@@ -8,10 +8,11 @@ EXAMPLE_DIR=$(dirname "$0")
 
 source "${EXAMPLE_DIR}"/run-configure.sh
 "${GMAKE_CMD}" clean-all
-"${GMAKE_CMD}" gateway-server-pki
-"${GMAKE_CMD}" client-pki
 "${GMAKE_CMD}" trust0-gateway
 "${GMAKE_CMD}" trust0-client
+"${GMAKE_CMD}" root-ca-pki
+"${GMAKE_CMD}" gateway-server-pki
+"${GMAKE_CMD}" client-pki
 
 # Run example in tmux session
 

--- a/example/run-echo-udp-example.sh
+++ b/example/run-echo-udp-example.sh
@@ -8,10 +8,11 @@ EXAMPLE_DIR=$(dirname "$0")
 
 source "${EXAMPLE_DIR}"/run-configure.sh
 "${GMAKE_CMD}" clean-all
-"${GMAKE_CMD}" gateway-server-pki
-"${GMAKE_CMD}" client-pki
 "${GMAKE_CMD}" trust0-gateway
 "${GMAKE_CMD}" trust0-client
+"${GMAKE_CMD}" root-ca-pki
+"${GMAKE_CMD}" gateway-server-pki
+"${GMAKE_CMD}" client-pki
 
 # Run example in tmux session
 

--- a/example/run-revoke-cert-example.sh
+++ b/example/run-revoke-cert-example.sh
@@ -8,11 +8,12 @@ EXAMPLE_DIR=$(dirname "$0")
 
 source "${EXAMPLE_DIR}"/run-configure.sh
 "${GMAKE_CMD}" clean-all
+"${GMAKE_CMD}" trust0-gateway
+"${GMAKE_CMD}" trust0-client
+"${GMAKE_CMD}" root-ca-pki
 "${GMAKE_CMD}" gateway-server-pki
 "${GMAKE_CMD}" client-pki
 "${GMAKE_CMD}" setup-crl-files
-"${GMAKE_CMD}" trust0-gateway
-"${GMAKE_CMD}" trust0-client
 
 # Run example in tmux session
 


### PR DESCRIPTION
### Summary

A new library and `trust0-pki-manager` tool is available with this PR. This is used to create certificate revocation list (CRL) files, usable in a Trust0 gateway.

Additionally the example code can be configured for all of its PKI resource creation (keys, certs, crls)  to use either `OpenSSL` or via the `trust0-pki-manager` tool (defaults to use the Trust0 tool).