### PR TITLE
[TASK] Bump version to 0.7.0-alpha

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "trust0-client"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "trust0-common"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -3065,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "trust0-gateway"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trust0-client"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 description = "Trust0 SDP Service Proxy Client"
 repository = "https://github.com/chewyfish/trust0"
 edition = "2021"
@@ -27,7 +27,7 @@ sct = "0.7.1"
 serde = { version = "*", features = ["derive"] }
 serde_derive = "*"
 serde_json = { version = "*", features = ["arbitrary_precision"] }
-trust0-common = { version = "0.6.0-alpha", path = "../common" }
+trust0-common = { version = "0.7.0-alpha", path = "../common" }
 webpki-roots = "0.25"
 
 [dev-dependencies]

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trust0-common"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 description = "Trust0 SDP Shared Codebase"
 repository = "https://github.com/chewyfish/trust0"
 edition = "2021"

--- a/crates/gateway/Cargo.toml
+++ b/crates/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trust0-gateway"
-version = "0.6.0-alpha"
+version = "0.7.0-alpha"
 description = "Trust0 SDP Service Proxy Gateway"
 repository = "https://github.com/chewyfish/trust0"
 edition = "2021"
@@ -35,7 +35,7 @@ serde_derive = "*"
 serde_json = { version = "*", features = ["arbitrary_precision"] }
 shlex = "1.2.0"
 time = { version = "0.3.34", default-features = false }
-trust0-common = { version = "0.6.0-alpha", path = "../common" }
+trust0-common = { version = "0.7.0-alpha", path = "../common" }
 webpki-roots = "0.26.0"
 x509-parser = "0.15.1"
 regex = "1.10.2"


### PR DESCRIPTION
### Summary

Update crates' version to `0.7.0-alpha`